### PR TITLE
Add Window Function Capabilities to DataFrame DSL

### DIFF
--- a/src/main/resources/pure/dsl/dataframe/dataframe.pure
+++ b/src/main/resources/pure/dsl/dataframe/dataframe.pure
@@ -198,6 +198,71 @@ Class meta::pure::dsl::dataframe::metamodel::MaxFunction extends AggregateFuncti
 {
 }
 
+// Window function classes
+Class meta::pure::dsl::dataframe::metamodel::WindowFunction extends FunctionExpression
+{
+   window : Window[1];
+}
+
+Class meta::pure::dsl::dataframe::metamodel::Window
+{
+   partitionBy : Expression[*];
+   orderBy : OrderByClause[*];
+   frameType : WindowFrameType[0..1];
+   frameStart : WindowFrameBound[0..1];
+   frameEnd : WindowFrameBound[0..1];
+}
+
+Enum meta::pure::dsl::dataframe::metamodel::WindowFrameType
+{
+   ROWS,
+   RANGE
+}
+
+Class meta::pure::dsl::dataframe::metamodel::WindowFrameBound
+{
+   type : WindowFrameBoundType[1];
+   offset : Integer[0..1];
+}
+
+Enum meta::pure::dsl::dataframe::metamodel::WindowFrameBoundType
+{
+   UNBOUNDED_PRECEDING,
+   PRECEDING,
+   CURRENT_ROW,
+   FOLLOWING,
+   UNBOUNDED_FOLLOWING
+}
+
+// Specialized window functions
+Class meta::pure::dsl::dataframe::metamodel::RowNumberFunction extends WindowFunction
+{
+}
+
+Class meta::pure::dsl::dataframe::metamodel::RankFunction extends WindowFunction
+{
+}
+
+Class meta::pure::dsl::dataframe::metamodel::DenseRankFunction extends WindowFunction
+{
+}
+
+Class meta::pure::dsl::dataframe::metamodel::LeadLagFunction extends WindowFunction
+{
+   offset : Expression[0..1];
+   defaultValue : Expression[0..1];
+   ignoreNulls : Boolean[0..1];
+}
+
+Class meta::pure::dsl::dataframe::metamodel::FirstLastValueFunction extends WindowFunction
+{
+   ignoreNulls : Boolean[0..1];
+}
+
+Class meta::pure::dsl::dataframe::metamodel::AggregateWindowFunction extends WindowFunction
+{
+}
+
 // Factory functions for creating DataFrame objects
 function meta::pure::dsl::dataframe::newDataFrame(): DataFrame[1]
 {
@@ -417,4 +482,146 @@ function meta::pure::dsl::dataframe::asc(expr: Expression[1]): OrderByClause[1]
 function meta::pure::dsl::dataframe::desc(expr: Expression[1]): OrderByClause[1]
 {
    ^OrderByClause(expression = $expr, direction = SortDirection.DESC)
+}
+
+// Window function helper functions
+function meta::pure::dsl::dataframe::over(expr: Expression[1], window: Window[1]): WindowFunction[1]
+{
+   ^WindowFunction(functionName = 'window', parameters = [$expr], window = $window);
+}
+
+function meta::pure::dsl::dataframe::partitionBy(columns: Expression[*]): Window[1]
+{
+   ^Window(partitionBy = $columns, orderBy = []);
+}
+
+function meta::pure::dsl::dataframe::orderBy(window: Window[1], clauses: OrderByClause[*]): Window[1]
+{
+   ^$window(orderBy = $clauses);
+}
+
+function meta::pure::dsl::dataframe::rowsUnboundedPreceding(window: Window[1]): Window[1]
+{
+   ^$window(
+      frameType = WindowFrameType.ROWS, 
+      frameStart = ^WindowFrameBound(type = WindowFrameBoundType.UNBOUNDED_PRECEDING),
+      frameEnd = ^WindowFrameBound(type = WindowFrameBoundType.CURRENT_ROW)
+   );
+}
+
+function meta::pure::dsl::dataframe::rowsBetween(window: Window[1], start: WindowFrameBound[1], end: WindowFrameBound[1]): Window[1]
+{
+   ^$window(frameType = WindowFrameType.ROWS, frameStart = $start, frameEnd = $end);
+}
+
+function meta::pure::dsl::dataframe::rangeBetween(window: Window[1], start: WindowFrameBound[1], end: WindowFrameBound[1]): Window[1]
+{
+   ^$window(frameType = WindowFrameType.RANGE, frameStart = $start, frameEnd = $end);
+}
+
+function meta::pure::dsl::dataframe::unboundedPreceding(): WindowFrameBound[1]
+{
+   ^WindowFrameBound(type = WindowFrameBoundType.UNBOUNDED_PRECEDING);
+}
+
+function meta::pure::dsl::dataframe::unboundedFollowing(): WindowFrameBound[1]
+{
+   ^WindowFrameBound(type = WindowFrameBoundType.UNBOUNDED_FOLLOWING);
+}
+
+function meta::pure::dsl::dataframe::currentRow(): WindowFrameBound[1]
+{
+   ^WindowFrameBound(type = WindowFrameBoundType.CURRENT_ROW);
+}
+
+function meta::pure::dsl::dataframe::preceding(offset: Integer[1]): WindowFrameBound[1]
+{
+   ^WindowFrameBound(type = WindowFrameBoundType.PRECEDING, offset = $offset);
+}
+
+function meta::pure::dsl::dataframe::following(offset: Integer[1]): WindowFrameBound[1]
+{
+   ^WindowFrameBound(type = WindowFrameBoundType.FOLLOWING, offset = $offset);
+}
+
+// Specific window functions
+function meta::pure::dsl::dataframe::rowNumber(window: Window[1]): RowNumberFunction[1]
+{
+   ^RowNumberFunction(functionName = 'row_number', parameters = [], window = $window);
+}
+
+function meta::pure::dsl::dataframe::rank(window: Window[1]): RankFunction[1]
+{
+   ^RankFunction(functionName = 'rank', parameters = [], window = $window);
+}
+
+function meta::pure::dsl::dataframe::denseRank(window: Window[1]): DenseRankFunction[1]
+{
+   ^DenseRankFunction(functionName = 'dense_rank', parameters = [], window = $window);
+}
+
+function meta::pure::dsl::dataframe::lead(expr: Expression[1], window: Window[1]): LeadLagFunction[1]
+{
+   ^LeadLagFunction(functionName = 'lead', parameters = [$expr], window = $window);
+}
+
+function meta::pure::dsl::dataframe::lead(expr: Expression[1], offset: Integer[1], window: Window[1]): LeadLagFunction[1]
+{
+   ^LeadLagFunction(functionName = 'lead', parameters = [$expr], window = $window, offset = literal($offset));
+}
+
+function meta::pure::dsl::dataframe::lead(expr: Expression[1], offset: Integer[1], defaultValue: Expression[1], window: Window[1]): LeadLagFunction[1]
+{
+   ^LeadLagFunction(functionName = 'lead', parameters = [$expr], window = $window, offset = literal($offset), defaultValue = $defaultValue);
+}
+
+function meta::pure::dsl::dataframe::lag(expr: Expression[1], window: Window[1]): LeadLagFunction[1]
+{
+   ^LeadLagFunction(functionName = 'lag', parameters = [$expr], window = $window);
+}
+
+function meta::pure::dsl::dataframe::lag(expr: Expression[1], offset: Integer[1], window: Window[1]): LeadLagFunction[1]
+{
+   ^LeadLagFunction(functionName = 'lag', parameters = [$expr], window = $window, offset = literal($offset));
+}
+
+function meta::pure::dsl::dataframe::lag(expr: Expression[1], offset: Integer[1], defaultValue: Expression[1], window: Window[1]): LeadLagFunction[1]
+{
+   ^LeadLagFunction(functionName = 'lag', parameters = [$expr], window = $window, offset = literal($offset), defaultValue = $defaultValue);
+}
+
+function meta::pure::dsl::dataframe::firstValue(expr: Expression[1], window: Window[1]): FirstLastValueFunction[1]
+{
+   ^FirstLastValueFunction(functionName = 'first_value', parameters = [$expr], window = $window);
+}
+
+function meta::pure::dsl::dataframe::lastValue(expr: Expression[1], window: Window[1]): FirstLastValueFunction[1]
+{
+   ^FirstLastValueFunction(functionName = 'last_value', parameters = [$expr], window = $window);
+}
+
+// Aggregate window functions
+function meta::pure::dsl::dataframe::sumOver(expr: Expression[1], window: Window[1]): AggregateWindowFunction[1]
+{
+   ^AggregateWindowFunction(functionName = 'sum', parameters = [$expr], window = $window);
+}
+
+function meta::pure::dsl::dataframe::avgOver(expr: Expression[1], window: Window[1]): AggregateWindowFunction[1]
+{
+   ^AggregateWindowFunction(functionName = 'avg', parameters = [$expr], window = $window);
+}
+
+function meta::pure::dsl::dataframe::minOver(expr: Expression[1], window: Window[1]): AggregateWindowFunction[1]
+{
+   ^AggregateWindowFunction(functionName = 'min', parameters = [$expr], window = $window);
+}
+
+function meta::pure::dsl::dataframe::maxOver(expr: Expression[1], window: Window[1]): AggregateWindowFunction[1]
+{
+   ^AggregateWindowFunction(functionName = 'max', parameters = [$expr], window = $window);
+}
+
+function meta::pure::dsl::dataframe::countOver(expr: Expression[1], window: Window[1]): AggregateWindowFunction[1]
+{
+   ^AggregateWindowFunction(functionName = 'count', parameters = [$expr], window = $window);
 }

--- a/src/main/resources/pure/dsl/duckdb/duckdb.pure
+++ b/src/main/resources/pure/dsl/duckdb/duckdb.pure
@@ -132,7 +132,68 @@ function <<access.private>> meta::pure::dsl::duckdb::generateDuckDBFunction(func
    $func->match([
       c: CountFunction[1] | 'COUNT(' + if($c.distinct == true, 'DISTINCT ', '') + $c.parameters->map(p | $p->generateDuckDBExpression())->joinStrings(', ') + ')',
       a: AggregateFunction[1] | $a.functionName->toUpperCase() + '(' + $a.parameters->map(p | $p->generateDuckDBExpression())->joinStrings(', ') + ')',
+      w: WindowFunction[1] | $w->generateDuckDBWindowFunction(),
       f: FunctionExpression[1] | $f.functionName + '(' + $f.parameters->map(p | $p->generateDuckDBExpression())->joinStrings(', ') + ')'
+   ])
+}
+
+// Generate SQL for window functions
+function <<access.private>> meta::pure::dsl::duckdb::generateDuckDBWindowFunction(func: WindowFunction[1]): String[1]
+{
+   let functionCall = $func->match([
+      r: RowNumberFunction[1] | 'ROW_NUMBER()',
+      r: RankFunction[1] | 'RANK()',
+      d: DenseRankFunction[1] | 'DENSE_RANK()',
+      l: LeadLagFunction[1] | $l.functionName->toUpperCase() + '(' + 
+                                $l.parameters->map(p | $p->generateDuckDBExpression())->joinStrings(', ') +
+                                if($l.offset->isNotEmpty(), ', ' + $l.offset->toOne()->generateDuckDBExpression(), '') + 
+                                if($l.defaultValue->isNotEmpty(), ', ' + $l.defaultValue->toOne()->generateDuckDBExpression(), '') +
+                                ')',
+      f: FirstLastValueFunction[1] | $f.functionName->toUpperCase() + '(' + 
+                                      $f.parameters->map(p | $p->generateDuckDBExpression())->joinStrings(', ') + 
+                                      ')' + if($f.ignoreNulls == true, ' IGNORE NULLS', ''),
+      a: AggregateWindowFunction[1] | $a.functionName->toUpperCase() + '(' + 
+                                      $a.parameters->map(p | $p->generateDuckDBExpression())->joinStrings(', ') + 
+                                      ')',
+      w: WindowFunction[1] | $w.functionName + '(' + 
+                              $w.parameters->map(p | $p->generateDuckDBExpression())->joinStrings(', ') + 
+                              ')'
+   ]);
+   
+   $functionCall + ' OVER(' + $func.window->generateDuckDBWindow() + ')';
+}
+
+// Generate SQL for window specification
+function <<access.private>> meta::pure::dsl::duckdb::generateDuckDBWindow(window: Window[1]): String[1]
+{
+   let partitionBy = if($window.partitionBy->isEmpty(), 
+                       '', 
+                       'PARTITION BY ' + $window.partitionBy->map(e | $e->generateDuckDBExpression())->joinStrings(', '));
+   
+   let orderBy = if($window.orderBy->isEmpty(), 
+                    '', 
+                    if($partitionBy->isEmpty(), '', ' ') + 
+                    'ORDER BY ' + $window.orderBy->map(o | $o.expression->generateDuckDBExpression() + ' ' + $o.direction->toString())->joinStrings(', '));
+   
+   let frame = if($window.frameType->isEmpty(), 
+                 '', 
+                 if($partitionBy->isEmpty() && $orderBy->isEmpty(), '', ' ') + 
+                 $window.frameType->toOne()->toString() + ' BETWEEN ' + 
+                 $window.frameStart->toOne()->generateDuckDBWindowFrameBound() + ' AND ' + 
+                 $window.frameEnd->toOne()->generateDuckDBWindowFrameBound());
+   
+   $partitionBy + $orderBy + $frame;
+}
+
+// Generate SQL for window frame bounds
+function <<access.private>> meta::pure::dsl::duckdb::generateDuckDBWindowFrameBound(bound: WindowFrameBound[1]): String[1]
+{
+   $bound.type->match([
+      WindowFrameBoundType.UNBOUNDED_PRECEDING | 'UNBOUNDED PRECEDING',
+      WindowFrameBoundType.PRECEDING | $bound.offset->toOne()->toString() + ' PRECEDING',
+      WindowFrameBoundType.CURRENT_ROW | 'CURRENT ROW',
+      WindowFrameBoundType.FOLLOWING | $bound.offset->toOne()->toString() + ' FOLLOWING',
+      WindowFrameBoundType.UNBOUNDED_FOLLOWING | 'UNBOUNDED FOLLOWING'
    ])
 }
 

--- a/src/main/resources/pure/dsl/snowflake/snowflake.pure
+++ b/src/main/resources/pure/dsl/snowflake/snowflake.pure
@@ -132,7 +132,68 @@ function <<access.private>> meta::pure::dsl::snowflake::generateSnowflakeFunctio
    $func->match([
       c: CountFunction[1] | 'COUNT(' + if($c.distinct == true, 'DISTINCT ', '') + $c.parameters->map(p | $p->generateSnowflakeExpression())->joinStrings(', ') + ')',
       a: AggregateFunction[1] | $a.functionName->toUpperCase() + '(' + $a.parameters->map(p | $p->generateSnowflakeExpression())->joinStrings(', ') + ')',
+      w: WindowFunction[1] | $w->generateSnowflakeWindowFunction(),
       f: FunctionExpression[1] | $f.functionName + '(' + $f.parameters->map(p | $p->generateSnowflakeExpression())->joinStrings(', ') + ')'
+   ])
+}
+
+// Generate SQL for window functions
+function <<access.private>> meta::pure::dsl::snowflake::generateSnowflakeWindowFunction(func: WindowFunction[1]): String[1]
+{
+   let functionCall = $func->match([
+      r: RowNumberFunction[1] | 'ROW_NUMBER()',
+      r: RankFunction[1] | 'RANK()',
+      d: DenseRankFunction[1] | 'DENSE_RANK()',
+      l: LeadLagFunction[1] | $l.functionName->toUpperCase() + '(' + 
+                                $l.parameters->map(p | $p->generateSnowflakeExpression())->joinStrings(', ') +
+                                if($l.offset->isNotEmpty(), ', ' + $l.offset->toOne()->generateSnowflakeExpression(), '') + 
+                                if($l.defaultValue->isNotEmpty(), ', ' + $l.defaultValue->toOne()->generateSnowflakeExpression(), '') +
+                                ')',
+      f: FirstLastValueFunction[1] | $f.functionName->toUpperCase() + '(' + 
+                                      $f.parameters->map(p | $p->generateSnowflakeExpression())->joinStrings(', ') + 
+                                      ')' + if($f.ignoreNulls == true, ' IGNORE NULLS', ''),
+      a: AggregateWindowFunction[1] | $a.functionName->toUpperCase() + '(' + 
+                                      $a.parameters->map(p | $p->generateSnowflakeExpression())->joinStrings(', ') + 
+                                      ')',
+      w: WindowFunction[1] | $w.functionName + '(' + 
+                              $w.parameters->map(p | $p->generateSnowflakeExpression())->joinStrings(', ') + 
+                              ')'
+   ]);
+   
+   $functionCall + ' OVER(' + $func.window->generateSnowflakeWindow() + ')';
+}
+
+// Generate SQL for window specification
+function <<access.private>> meta::pure::dsl::snowflake::generateSnowflakeWindow(window: Window[1]): String[1]
+{
+   let partitionBy = if($window.partitionBy->isEmpty(), 
+                       '', 
+                       'PARTITION BY ' + $window.partitionBy->map(e | $e->generateSnowflakeExpression())->joinStrings(', '));
+   
+   let orderBy = if($window.orderBy->isEmpty(), 
+                    '', 
+                    if($partitionBy->isEmpty(), '', ' ') + 
+                    'ORDER BY ' + $window.orderBy->map(o | $o.expression->generateSnowflakeExpression() + ' ' + $o.direction->toString())->joinStrings(', '));
+   
+   let frame = if($window.frameType->isEmpty(), 
+                 '', 
+                 if($partitionBy->isEmpty() && $orderBy->isEmpty(), '', ' ') + 
+                 $window.frameType->toOne()->toString() + ' BETWEEN ' + 
+                 $window.frameStart->toOne()->generateSnowflakeWindowFrameBound() + ' AND ' + 
+                 $window.frameEnd->toOne()->generateSnowflakeWindowFrameBound());
+   
+   $partitionBy + $orderBy + $frame;
+}
+
+// Generate SQL for window frame bounds
+function <<access.private>> meta::pure::dsl::snowflake::generateSnowflakeWindowFrameBound(bound: WindowFrameBound[1]): String[1]
+{
+   $bound.type->match([
+      WindowFrameBoundType.UNBOUNDED_PRECEDING | 'UNBOUNDED PRECEDING',
+      WindowFrameBoundType.PRECEDING | $bound.offset->toOne()->toString() + ' PRECEDING',
+      WindowFrameBoundType.CURRENT_ROW | 'CURRENT ROW',
+      WindowFrameBoundType.FOLLOWING | $bound.offset->toOne()->toString() + ' FOLLOWING',
+      WindowFrameBoundType.UNBOUNDED_FOLLOWING | 'UNBOUNDED FOLLOWING'
    ])
 }
 

--- a/src/test/resources/pure/dsl/tests/dataframe_tests.pure
+++ b/src/test/resources/pure/dsl/tests/dataframe_tests.pure
@@ -221,6 +221,174 @@ function <<test.Test>> meta::pure::dsl::tests::testDatabaseSpecificSyntaxDiffere
    true;
 }
 
+// Window Function Tests
+
+function <<test.Test>> meta::pure::dsl::tests::testWindowFunctionsBasic(): Boolean[1]
+{
+   // Create a SELECT query with basic window functions
+   let df = select([
+      as(col('id'), 'id'),
+      as(col('name'), 'name'),
+      as(rowNumber(partitionBy([col('category')])->orderBy([asc(col('id'))])), 'row_num')
+   ])->from(table('employees'));
+   
+   // Generate SQL for Snowflake
+   let snowflakeSQL = $df->generateSnowflakeSQL();
+   assertEquals('SELECT id AS id, name AS name, ROW_NUMBER() OVER(PARTITION BY category ORDER BY id ASC) AS row_num\nFROM employees', $snowflakeSQL);
+   
+   // Generate SQL for DuckDB
+   let duckdbSQL = $df->generateDuckDBSQL();
+   assertEquals('SELECT id AS id, name AS name, ROW_NUMBER() OVER(PARTITION BY category ORDER BY id ASC) AS row_num\nFROM employees', $duckdbSQL);
+   
+   true;
+}
+
+function <<test.Test>> meta::pure::dsl::tests::testWindowFunctionsWithFrames(): Boolean[1]
+{
+   // Create a SELECT query with window functions that use frames
+   let df = select([
+      as(col('id'), 'id'),
+      as(col('sales'), 'sales'),
+      as(sumOver(col('sales'), partitionBy([col('region')])
+                               ->orderBy([asc(col('date'))])
+                               ->rowsBetween(unboundedPreceding(), currentRow())), 'running_total'),
+      as(avgOver(col('sales'), partitionBy([col('region')])
+                               ->orderBy([asc(col('date'))])
+                               ->rowsBetween(preceding(2), following(2))), 'moving_avg')
+   ])->from(table('sales'));
+   
+   // Generate SQL for Snowflake
+   let snowflakeSQL = $df->generateSnowflakeSQL();
+   assertEquals('SELECT id AS id, sales AS sales, SUM(sales) OVER(PARTITION BY region ORDER BY date ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS running_total, AVG(sales) OVER(PARTITION BY region ORDER BY date ASC ROWS BETWEEN 2 PRECEDING AND 2 FOLLOWING) AS moving_avg\nFROM sales', $snowflakeSQL);
+   
+   // Generate SQL for DuckDB
+   let duckdbSQL = $df->generateDuckDBSQL();
+   assertEquals('SELECT id AS id, sales AS sales, SUM(sales) OVER(PARTITION BY region ORDER BY date ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS running_total, AVG(sales) OVER(PARTITION BY region ORDER BY date ASC ROWS BETWEEN 2 PRECEDING AND 2 FOLLOWING) AS moving_avg\nFROM sales', $duckdbSQL);
+   
+   true;
+}
+
+function <<test.Test>> meta::pure::dsl::tests::testWindowFunctionsWithRange(): Boolean[1]
+{
+   // Create a SELECT query with window functions that use RANGE frame type
+   let df = select([
+      as(col('id'), 'id'),
+      as(col('date'), 'date'),
+      as(col('sales'), 'sales'),
+      as(sumOver(col('sales'), partitionBy([col('region')])
+                               ->orderBy([asc(col('date'))])
+                               ->rangeBetween(unboundedPreceding(), currentRow())), 'running_total')
+   ])->from(table('sales'));
+   
+   // Generate SQL for Snowflake
+   let snowflakeSQL = $df->generateSnowflakeSQL();
+   assertEquals('SELECT id AS id, date AS date, sales AS sales, SUM(sales) OVER(PARTITION BY region ORDER BY date ASC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS running_total\nFROM sales', $snowflakeSQL);
+   
+   // Generate SQL for DuckDB
+   let duckdbSQL = $df->generateDuckDBSQL();
+   assertEquals('SELECT id AS id, date AS date, sales AS sales, SUM(sales) OVER(PARTITION BY region ORDER BY date ASC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS running_total\nFROM sales', $duckdbSQL);
+   
+   true;
+}
+
+function <<test.Test>> meta::pure::dsl::tests::testLeadLagWindowFunctions(): Boolean[1]
+{
+   // Create a SELECT query with LEAD and LAG window functions
+   let df = select([
+      as(col('id'), 'id'),
+      as(col('date'), 'date'),
+      as(col('sales'), 'sales'),
+      as(lead(col('sales'), partitionBy([col('region')])->orderBy([asc(col('date'))])), 'next_day_sales'),
+      as(lead(col('sales'), 2, literal(0), partitionBy([col('region')])->orderBy([asc(col('date'))])), 'sales_in_two_days'),
+      as(lag(col('sales'), partitionBy([col('region')])->orderBy([asc(col('date'))])), 'prev_day_sales'),
+      as(lag(col('sales'), 3, literal(0), partitionBy([col('region')])->orderBy([asc(col('date'))])), 'sales_three_days_ago')
+   ])->from(table('sales'));
+   
+   // Generate SQL for Snowflake
+   let snowflakeSQL = $df->generateSnowflakeSQL();
+   assertEquals('SELECT id AS id, date AS date, sales AS sales, LEAD(sales) OVER(PARTITION BY region ORDER BY date ASC) AS next_day_sales, LEAD(sales, 2, 0) OVER(PARTITION BY region ORDER BY date ASC) AS sales_in_two_days, LAG(sales) OVER(PARTITION BY region ORDER BY date ASC) AS prev_day_sales, LAG(sales, 3, 0) OVER(PARTITION BY region ORDER BY date ASC) AS sales_three_days_ago\nFROM sales', $snowflakeSQL);
+   
+   // Generate SQL for DuckDB
+   let duckdbSQL = $df->generateDuckDBSQL();
+   assertEquals('SELECT id AS id, date AS date, sales AS sales, LEAD(sales) OVER(PARTITION BY region ORDER BY date ASC) AS next_day_sales, LEAD(sales, 2, 0) OVER(PARTITION BY region ORDER BY date ASC) AS sales_in_two_days, LAG(sales) OVER(PARTITION BY region ORDER BY date ASC) AS prev_day_sales, LAG(sales, 3, 0) OVER(PARTITION BY region ORDER BY date ASC) AS sales_three_days_ago\nFROM sales', $duckdbSQL);
+   
+   true;
+}
+
+function <<test.Test>> meta::pure::dsl::tests::testRankingWindowFunctions(): Boolean[1]
+{
+   // Create a SELECT query with ranking window functions
+   let df = select([
+      as(col('id'), 'id'),
+      as(col('name'), 'name'),
+      as(col('score'), 'score'),
+      as(rank(partitionBy([col('department')])->orderBy([desc(col('score'))])), 'rank'),
+      as(denseRank(partitionBy([col('department')])->orderBy([desc(col('score'))])), 'dense_rank'),
+      as(rowNumber(partitionBy([col('department')])->orderBy([desc(col('score'))])), 'row_number')
+   ])->from(table('employees'));
+   
+   // Generate SQL for Snowflake
+   let snowflakeSQL = $df->generateSnowflakeSQL();
+   assertEquals('SELECT id AS id, name AS name, score AS score, RANK() OVER(PARTITION BY department ORDER BY score DESC) AS rank, DENSE_RANK() OVER(PARTITION BY department ORDER BY score DESC) AS dense_rank, ROW_NUMBER() OVER(PARTITION BY department ORDER BY score DESC) AS row_number\nFROM employees', $snowflakeSQL);
+   
+   // Generate SQL for DuckDB
+   let duckdbSQL = $df->generateDuckDBSQL();
+   assertEquals('SELECT id AS id, name AS name, score AS score, RANK() OVER(PARTITION BY department ORDER BY score DESC) AS rank, DENSE_RANK() OVER(PARTITION BY department ORDER BY score DESC) AS dense_rank, ROW_NUMBER() OVER(PARTITION BY department ORDER BY score DESC) AS row_number\nFROM employees', $duckdbSQL);
+   
+   true;
+}
+
+function <<test.Test>> meta::pure::dsl::tests::testFirstLastValueWindowFunctions(): Boolean[1]
+{
+   // Create a SELECT query with FIRST_VALUE and LAST_VALUE window functions
+   let df = select([
+      as(col('id'), 'id'),
+      as(col('date'), 'date'),
+      as(col('sales'), 'sales'),
+      as(firstValue(col('sales'), partitionBy([col('region')])
+                                  ->orderBy([asc(col('date'))])
+                                  ->rowsBetween(unboundedPreceding(), unboundedFollowing())), 'first_sale'),
+      as(lastValue(col('sales'), partitionBy([col('region')])
+                                 ->orderBy([asc(col('date'))])
+                                 ->rowsBetween(unboundedPreceding(), unboundedFollowing())), 'last_sale')
+   ])->from(table('sales'));
+   
+   // Generate SQL for Snowflake
+   let snowflakeSQL = $df->generateSnowflakeSQL();
+   assertEquals('SELECT id AS id, date AS date, sales AS sales, FIRST_VALUE(sales) OVER(PARTITION BY region ORDER BY date ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS first_sale, LAST_VALUE(sales) OVER(PARTITION BY region ORDER BY date ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS last_sale\nFROM sales', $snowflakeSQL);
+   
+   // Generate SQL for DuckDB
+   let duckdbSQL = $df->generateDuckDBSQL();
+   assertEquals('SELECT id AS id, date AS date, sales AS sales, FIRST_VALUE(sales) OVER(PARTITION BY region ORDER BY date ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS first_sale, LAST_VALUE(sales) OVER(PARTITION BY region ORDER BY date ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS last_sale\nFROM sales', $duckdbSQL);
+   
+   true;
+}
+
+function <<test.Test>> meta::pure::dsl::tests::testAggregateWindowFunctions(): Boolean[1]
+{
+   // Create a SELECT query with aggregate window functions
+   let df = select([
+      as(col('id'), 'id'),
+      as(col('department'), 'department'),
+      as(col('salary'), 'salary'),
+      as(sumOver(col('salary'), partitionBy([col('department')])), 'dept_total'),
+      as(avgOver(col('salary'), partitionBy([col('department')])), 'dept_avg'),
+      as(minOver(col('salary'), partitionBy([col('department')])), 'dept_min'),
+      as(maxOver(col('salary'), partitionBy([col('department')])), 'dept_max'),
+      as(countOver(col('id'), partitionBy([col('department')])), 'dept_count')
+   ])->from(table('employees'));
+   
+   // Generate SQL for Snowflake
+   let snowflakeSQL = $df->generateSnowflakeSQL();
+   assertEquals('SELECT id AS id, department AS department, salary AS salary, SUM(salary) OVER(PARTITION BY department) AS dept_total, AVG(salary) OVER(PARTITION BY department) AS dept_avg, MIN(salary) OVER(PARTITION BY department) AS dept_min, MAX(salary) OVER(PARTITION BY department) AS dept_max, COUNT(id) OVER(PARTITION BY department) AS dept_count\nFROM employees', $snowflakeSQL);
+   
+   // Generate SQL for DuckDB
+   let duckdbSQL = $df->generateDuckDBSQL();
+   assertEquals('SELECT id AS id, department AS department, salary AS salary, SUM(salary) OVER(PARTITION BY department) AS dept_total, AVG(salary) OVER(PARTITION BY department) AS dept_avg, MIN(salary) OVER(PARTITION BY department) AS dept_min, MAX(salary) OVER(PARTITION BY department) AS dept_max, COUNT(id) OVER(PARTITION BY department) AS dept_count\nFROM employees', $duckdbSQL);
+   
+   true;
+}
+
 // Helper function for testing
 function <<access.private>> meta::pure::dsl::tests::assertEquals(expected: String[1], actual: String[1]): Boolean[1]
 {


### PR DESCRIPTION
# Add Window Function Capabilities to DataFrame DSL

This PR adds comprehensive window function support to the Legend DataFrame DSL, enabling the modeling of SQL window functions that work with both Snowflake and DuckDB.

## Features Added

- **Window Function Metamodel**: Added classes for window functions, window specifications, and frame bounds
- **Helper Functions**: Implemented helper functions for creating window functions with various options
- **SQL Generators**: Updated both Snowflake and DuckDB SQL generators to support window function syntax
- **Comprehensive Tests**: Added tests for all window function types and features

## Window Function Types Supported

- Ranking functions (ROW_NUMBER, RANK, DENSE_RANK)
- Navigation functions (LEAD, LAG)
- Value functions (FIRST_VALUE, LAST_VALUE)
- Aggregate window functions (SUM, AVG, MIN, MAX, COUNT)

## Window Frame Support

- ROWS and RANGE frame types
- Frame bounds (UNBOUNDED PRECEDING/FOLLOWING, CURRENT ROW, n PRECEDING/FOLLOWING)
- Flexible window specifications with PARTITION BY and ORDER BY

Link to Devin run: https://app.devin.ai/sessions/6e3952ef0ea245a486f679a484d6c39c
Requested by: Neema Raphael
