### PR TITLE
Implement Full SELECT Functionality for BigQuery

### DIFF
--- a/src/main/resources/pure/dsl/bigquery/bigquery.pure
+++ b/src/main/resources/pure/dsl/bigquery/bigquery.pure
@@ -29,7 +29,13 @@ function meta::pure::dsl::bigquery::generateBigQuerySQL(df: DataFrame[1]): Strin
       pair('CHANGES', false),
       pair('CONNECT_BY', false),
       pair('SAMPLE', false),
-      pair('QUALIFY', true)
+      pair('QUALIFY', true),
+      pair('STRUCT', true),
+      pair('VALUE', true),
+      pair('EXCEPT', true),
+      pair('REPLACE', true),
+      pair('DIFFERENTIAL_PRIVACY', true),
+      pair('AGGREGATION_THRESHOLD', true)
    ]);
    
    meta::pure::dsl::dataframe::checkUnsupportedFeatures($df, 'BigQuery', $supportedFeatures);
@@ -66,11 +72,24 @@ function <<access.private>> meta::pure::dsl::bigquery::generateWithClause(df: Da
 // Generate the SELECT clause
 function <<access.private>> meta::pure::dsl::bigquery::generateSelectClause(df: DataFrame[1]): String[1]
 {
-   'SELECT ' + 
-   if($df.distinct, 'DISTINCT ', '') + 
+   let structPrefix = if($df.structOutput == true, 'AS STRUCT ', '');
+   let valuePrefix = if($df.valueOutput == true, 'AS VALUE ', '');
+   let prefix = $structPrefix + $valuePrefix;
+   
+   let exceptClause = if($df.exceptColumns->isEmpty(), 
+                         '', 
+                         ' EXCEPT (' + $df.exceptColumns->joinStrings(', ') + ')');
+   
+   let replaceClause = if($df.replaceColumns->isEmpty(), 
+                           '', 
+                           ' REPLACE (' + $df.replaceColumns->keyValues()->map(kv | 
+                                               $kv.first + ' AS ' + $kv.second->generateBigQueryExpression()
+                                            )->joinStrings(', ') + ')');
+   
+   'SELECT ' + if($df.distinct == true, 'DISTINCT ', '') + $prefix + 
    if($df.columns->isEmpty(), 
-      '*', 
-      $df.columns->map(c | $c->generateBigQueryExpression() + if($c.alias->isEmpty(), '', ' AS ' + $c.alias->toOne()))->joinStrings(', '));
+      '*' + $exceptClause + $replaceClause, 
+      $df.columns->map(c | $c.expression->generateBigQueryExpression() + if($c.alias->isNotEmpty(), ' AS ' + $c.alias->toOne(), ''))->joinStrings(', '));
 }
 
 // Generate the FROM clause
@@ -131,12 +150,46 @@ function <<access.private>> meta::pure::dsl::bigquery::generateOrderByClause(df:
       )->joinStrings(', '));
 }
 
-// Generate the LIMIT and OFFSET clauses
+// Generate the LIMIT and OFFSET clauses plus BigQuery-specific privacy clauses
 function <<access.private>> meta::pure::dsl::bigquery::generateLimitOffsetClause(df: DataFrame[1]): String[1]
 {
    let limitClause = if($df.limit->isEmpty(), '', '\nLIMIT ' + $df.limit->toOne()->toString());
    let offsetClause = if($df.offset->isEmpty(), '', '\nOFFSET ' + $df.offset->toOne()->toString());
-   $limitClause + $offsetClause;
+   let diffPrivacyClause = $df->generateDifferentialPrivacyClause();
+   let aggThresholdClause = $df->generateAggregationThresholdClause();
+   
+   $limitClause + $offsetClause + $diffPrivacyClause + $aggThresholdClause;
+}
+
+// Generate the WITH DIFFERENTIAL_PRIVACY clause
+function <<access.private>> meta::pure::dsl::bigquery::generateDifferentialPrivacyClause(df: DataFrame[1]): String[1]
+{
+   if($df.differentialPrivacy->isEmpty(), 
+      '', 
+      '\nWITH DIFFERENTIAL_PRIVACY OPTIONS(' + 
+         'epsilon=' + $df.differentialPrivacy->toOne().epsilon->toString() + 
+         if($df.differentialPrivacy->toOne().delta->isNotEmpty(), 
+            ', delta=' + $df.differentialPrivacy->toOne().delta->toOne()->toString(), 
+            '') +
+         if($df.differentialPrivacy->toOne().kappa->isNotEmpty(), 
+            ', kappa=' + $df.differentialPrivacy->toOne().kappa->toOne()->toString(), 
+            '') +
+         if($df.differentialPrivacy->toOne().sensitivityType->isNotEmpty(), 
+            ', sensitivity_type=' + $df.differentialPrivacy->toOne().sensitivityType->toOne()->toString() + 
+            ', sensitivity_value=' + $df.differentialPrivacy->toOne().sensitivityValue->toOne()->toString(), 
+            '') +
+      ')')
+}
+
+// Generate the WITH AGGREGATION_THRESHOLD clause
+function <<access.private>> meta::pure::dsl::bigquery::generateAggregationThresholdClause(df: DataFrame[1]): String[1]
+{
+   if($df.aggregationThreshold->isEmpty(), 
+      '', 
+      '\nWITH AGGREGATION_THRESHOLD ' + $df.aggregationThreshold->toOne().threshold->toString() +
+      if($df.aggregationThreshold->toOne().replaceWith->isNotEmpty(), 
+         ' REPLACE WITH ' + generateBigQueryLiteral($df.aggregationThreshold->toOne().replaceWith->toOne()), 
+         ''))
 }
 
 // Generate BigQuery expression for a column

--- a/src/main/resources/pure/dsl/dataframe/dataframe.pure
+++ b/src/main/resources/pure/dsl/dataframe/dataframe.pure
@@ -35,6 +35,24 @@ Class meta::pure::dsl::dataframe::metamodel::DataFrame
    offset : Integer[0..1];
    distinct : Boolean[0..1];
    ctes : CommonTableExpression[*];
+   
+   // Properties for Snowflake features
+   pivot : PivotClause[0..1];
+   unpivot : UnpivotClause[0..1];
+   matchRecognize : MatchRecognizeClause[0..1];
+   sample : SampleClause[0..1];
+   qualify : QualifyClause[0..1];
+   at : AtClause[0..1];
+   changes : ChangesClause[0..1];
+   connectBy : ConnectByClause[0..1];
+   
+   // Properties for BigQuery features
+   differentialPrivacy : DifferentialPrivacyClause[0..1];
+   aggregationThreshold : AggregationThresholdClause[0..1];
+   structOutput : Boolean[0..1];
+   valueOutput : Boolean[0..1];
+   exceptColumns : String[*];
+   replaceColumns : Map<String, Expression>[0..1];
 }
 
 // Column representation

--- a/src/main/resources/pure/dsl/dataframe/errorHandling.pure
+++ b/src/main/resources/pure/dsl/dataframe/errorHandling.pure
@@ -53,6 +53,30 @@ function meta::pure::dsl::dataframe::checkUnsupportedFeatures(df: DataFrame[1], 
    // Check QUALIFY support
    if($df.qualify->isNotEmpty() && !$supportedFeatures->get('QUALIFY')->defaultIfEmpty(false), 
       | throw('QUALIFY clause is not supported in ' + $database, []));
+   
+   // Check STRUCT output support
+   if($df.structOutput == true && !$supportedFeatures->get('STRUCT')->defaultIfEmpty(false), 
+      | throw('SELECT AS STRUCT is not supported in ' + $database, []));
+   
+   // Check VALUE output support
+   if($df.valueOutput == true && !$supportedFeatures->get('VALUE')->defaultIfEmpty(false), 
+      | throw('SELECT AS VALUE is not supported in ' + $database, []));
+   
+   // Check EXCEPT support
+   if($df.exceptColumns->isNotEmpty() && !$supportedFeatures->get('EXCEPT')->defaultIfEmpty(false), 
+      | throw('SELECT * EXCEPT is not supported in ' + $database, []));
+   
+   // Check REPLACE support
+   if($df.replaceColumns->isNotEmpty() && !$supportedFeatures->get('REPLACE')->defaultIfEmpty(false), 
+      | throw('SELECT * REPLACE is not supported in ' + $database, []));
+   
+   // Check DIFFERENTIAL_PRIVACY support
+   if($df.differentialPrivacy->isNotEmpty() && !$supportedFeatures->get('DIFFERENTIAL_PRIVACY')->defaultIfEmpty(false), 
+      | throw('WITH DIFFERENTIAL_PRIVACY is not supported in ' + $database, []));
+   
+   // Check AGGREGATION_THRESHOLD support
+   if($df.aggregationThreshold->isNotEmpty() && !$supportedFeatures->get('AGGREGATION_THRESHOLD')->defaultIfEmpty(false), 
+      | throw('WITH AGGREGATION_THRESHOLD is not supported in ' + $database, []));
 }
 
 // Helper function to create feature support map

--- a/src/main/resources/pure/dsl/dataframe/metamodel/bigquery.pure
+++ b/src/main/resources/pure/dsl/dataframe/metamodel/bigquery.pure
@@ -1,0 +1,46 @@
+// Copyright 2025 Neema Raphael
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::dsl::dataframe::*;
+import meta::pure::dsl::dataframe::metamodel::*;
+
+/**
+ * Metamodel classes for BigQuery-specific SELECT features
+ */
+
+// Differential Privacy clause
+Class meta::pure::dsl::dataframe::metamodel::DifferentialPrivacyClause
+{
+   epsilon : Float[1];
+   delta : Float[0..1];
+   kappa : Float[0..1];
+   sensitivityType : SensitivityType[0..1];
+   sensitivityValue : Float[0..1];
+}
+
+// Sensitivity type for differential privacy
+Enum meta::pure::dsl::dataframe::metamodel::SensitivityType
+{
+   SUM,
+   MEAN,
+   COUNT,
+   QUANTILES
+}
+
+// Aggregation Threshold clause
+Class meta::pure::dsl::dataframe::metamodel::AggregationThresholdClause
+{
+   threshold : Integer[1];
+   replaceWith : Any[0..1];
+}

--- a/src/main/resources/pure/dsl/dataframe/selectFeatures.pure
+++ b/src/main/resources/pure/dsl/dataframe/selectFeatures.pure
@@ -1,0 +1,82 @@
+// Copyright 2025 Neema Raphael
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::dsl::dataframe::*;
+import meta::pure::dsl::dataframe::metamodel::*;
+
+// Helper functions for BigQuery-specific features
+
+// Set SELECT AS STRUCT
+function meta::pure::dsl::dataframe::asStruct(df: DataFrame[1]): DataFrame[1]
+{
+   ^$df(structOutput = true, valueOutput = false);
+}
+
+// Set SELECT AS VALUE
+function meta::pure::dsl::dataframe::asValue(df: DataFrame[1]): DataFrame[1]
+{
+   ^$df(valueOutput = true, structOutput = false);
+}
+
+// Add SELECT * EXCEPT
+function meta::pure::dsl::dataframe::except(df: DataFrame[1], columns: String[*]): DataFrame[1]
+{
+   ^$df(exceptColumns = $columns);
+}
+
+// Add SELECT * EXCEPT with column specifications
+function meta::pure::dsl::dataframe::except<T>(df: DataFrame[1], cols: ColSpecArray<T>[1]): DataFrame[1]
+{
+   ^$df(exceptColumns = $cols.names);
+}
+
+// Add SELECT * EXCEPT with single column
+function meta::pure::dsl::dataframe::except<T>(df: DataFrame[1], col: ColSpec<T>[1]): DataFrame[1]
+{
+   ^$df(exceptColumns = [$col.name]);
+}
+
+// Add SELECT * REPLACE
+function meta::pure::dsl::dataframe::replace(df: DataFrame[1], replacements: Map<String, Expression>[1]): DataFrame[1]
+{
+   ^$df(replaceColumns = $replacements);
+}
+
+// Add WITH DIFFERENTIAL_PRIVACY
+function meta::pure::dsl::dataframe::withDifferentialPrivacy(df: DataFrame[1], epsilon: Float[1], delta: Float[0..1], kappa: Float[0..1]): DataFrame[1]
+{
+   ^$df(differentialPrivacy = ^DifferentialPrivacyClause(epsilon = $epsilon, delta = $delta, kappa = $kappa));
+}
+
+// Add WITH DIFFERENTIAL_PRIVACY with sensitivity
+function meta::pure::dsl::dataframe::withDifferentialPrivacy(df: DataFrame[1], epsilon: Float[1], sensitivityType: SensitivityType[1], sensitivityValue: Float[1]): DataFrame[1]
+{
+   ^$df(differentialPrivacy = ^DifferentialPrivacyClause(
+      epsilon = $epsilon, 
+      sensitivityType = $sensitivityType,
+      sensitivityValue = $sensitivityValue
+   ));
+}
+
+// Add WITH AGGREGATION_THRESHOLD
+function meta::pure::dsl::dataframe::withAggregationThreshold(df: DataFrame[1], threshold: Integer[1]): DataFrame[1]
+{
+   ^$df(aggregationThreshold = ^AggregationThresholdClause(threshold = $threshold));
+}
+
+// Add WITH AGGREGATION_THRESHOLD with replacement value
+function meta::pure::dsl::dataframe::withAggregationThreshold(df: DataFrame[1], threshold: Integer[1], replaceWith: Any[1]): DataFrame[1]
+{
+   ^$df(aggregationThreshold = ^AggregationThresholdClause(threshold = $threshold, replaceWith = $replaceWith));
+}

--- a/src/main/resources/pure/dsl/examples/bigquery_features.pure
+++ b/src/main/resources/pure/dsl/examples/bigquery_features.pure
@@ -1,0 +1,139 @@
+// Copyright 2025 Neema Raphael
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::dsl::dataframe::*;
+import meta::pure::dsl::dataframe::metamodel::*;
+import meta::pure::dsl::bigquery::*;
+
+function <<functionType.Example>> meta::pure::dsl::examples::bigquery::structValueExample(): Any[*]
+{
+   // Example of SELECT AS STRUCT
+   let structExample = table('employees')
+      ->asStruct()
+      ->select([~id, ~name, ~department, ~salary]);
+   
+   print('SELECT AS STRUCT example:');
+   print(generateBigQuerySQL($structExample));
+   print('\n');
+   
+   // Example of SELECT AS VALUE
+   let valueExample = table('employees')
+      ->asValue()
+      ->select([~id]);
+   
+   print('SELECT AS VALUE example:');
+   print(generateBigQuerySQL($valueExample));
+   print('\n');
+}
+
+function <<functionType.Example>> meta::pure::dsl::examples::bigquery::exceptReplaceExample(): Any[*]
+{
+   // Example of SELECT * EXCEPT
+   let exceptExample = table('employees')
+      ->except(['created_at', 'updated_at']);
+   
+   print('SELECT * EXCEPT example:');
+   print(generateBigQuerySQL($exceptExample));
+   print('\n');
+   
+   // Example of SELECT * REPLACE
+   let replacements = newMap([
+      pair('salary', ^FunctionExpression(functionName = 'FORMAT', parameters = [col('salary'), literal('$%.2f')])),
+      pair('hire_date', ^FunctionExpression(functionName = 'FORMAT_DATE', parameters = [literal('%Y-%m-%d'), col('hire_date')]))
+   ]);
+   
+   let replaceExample = table('employees')
+      ->replace($replacements);
+   
+   print('SELECT * REPLACE example:');
+   print(generateBigQuerySQL($replaceExample));
+   print('\n');
+}
+
+function <<functionType.Example>> meta::pure::dsl::examples::bigquery::privacyExample(): Any[*]
+{
+   // Example of WITH DIFFERENTIAL_PRIVACY
+   let privacyExample = table('salary_data')
+      ->groupBy([~department, ~position])
+      ->extend([
+         avg(~salary)->as('avg_salary'),
+         count(~id)->as('employee_count')
+      ])
+      ->withDifferentialPrivacy(0.1, 0.001, 1.0);
+   
+   print('WITH DIFFERENTIAL_PRIVACY example:');
+   print(generateBigQuerySQL($privacyExample));
+   print('\n');
+   
+   // Example of WITH AGGREGATION_THRESHOLD
+   let thresholdExample = table('salary_data')
+      ->groupBy([~department, ~position])
+      ->extend([
+         avg(~salary)->as('avg_salary'),
+         count(~id)->as('employee_count')
+      ])
+      ->withAggregationThreshold(10, 'NULL');
+   
+   print('WITH AGGREGATION_THRESHOLD example:');
+   print(generateBigQuerySQL($thresholdExample));
+   print('\n');
+}
+
+function <<functionType.Example>> meta::pure::dsl::examples::bigquery::combinedExample(): Any[*]
+{
+   // Comprehensive example combining multiple BigQuery features
+   let query = table('employee_data')
+      ->asStruct()
+      ->except(['ssn', 'bank_account'])
+      ->filter({e | $e.status == 'ACTIVE'})
+      ->groupBy([~department, ~position])
+      ->extend([
+         count(~id)->as('count'),
+         avg(~salary)->as('avg_salary'),
+         min(~salary)->as('min_salary'),
+         max(~salary)->as('max_salary')
+      ])
+      ->orderBy([desc(~count)])
+      ->withDifferentialPrivacy(0.1, SensitivityType.MEAN, 10000.0)
+      ->withAggregationThreshold(5);
+   
+   print('Comprehensive BigQuery example:');
+   print(generateBigQuerySQL($query));
+   print('\n');
+}
+
+function <<functionType.Example>> meta::pure::dsl::examples::bigquery::inlineTDSExample(): Any[*]
+{
+   // Example of inline TDS with BigQuery
+   let inlineData = inlineTDS(['id', 'name', 'department', 'salary'], [
+      [1, 'Alice', 'Engineering', 100000],
+      [2, 'Bob', 'Marketing', 90000],
+      [3, 'Charlie', 'Engineering', 110000],
+      [4, 'Diana', 'Sales', 95000]
+   ]);
+   
+   // Query using inline TDS
+   let query = $inlineData
+      ->filter({e | $e.salary > 95000})
+      ->groupBy([~department])
+      ->extend([
+         count()->as('employee_count'),
+         avg(~salary)->as('avg_salary')
+      ])
+      ->orderBy([desc(~avg_salary)]);
+   
+   print('BigQuery inline TDS example:');
+   print(generateBigQuerySQL($query));
+   print('\n');
+}

--- a/src/test/resources/pure/dsl/tests/bigquery_features_tests.pure
+++ b/src/test/resources/pure/dsl/tests/bigquery_features_tests.pure
@@ -1,0 +1,170 @@
+// Copyright 2025 Neema Raphael
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::dsl::dataframe::*;
+import meta::pure::dsl::dataframe::metamodel::*;
+import meta::pure::dsl::bigquery::*;
+
+function <<test.Test>> meta::pure::dsl::tests::testBigQueryStructValueOutput(): Boolean[1]
+{
+   // Test SELECT AS STRUCT
+   let dfStruct = table('employees')->asStruct();
+   let sqlStruct = $dfStruct->generateBigQuerySQL();
+   assert($sqlStruct->contains('SELECT AS STRUCT *'), 'BigQuery SQL should generate AS STRUCT selector');
+   
+   // Test SELECT AS VALUE
+   let dfValue = table('employees')->asValue();
+   let sqlValue = $dfValue->generateBigQuerySQL();
+   assert($sqlValue->contains('SELECT AS VALUE *'), 'BigQuery SQL should generate AS VALUE selector');
+   
+   // Test error handling in other databases
+   let errorThrown = false;
+   try
+   {
+      $dfStruct->generateSnowflakeSQL();
+   }
+   catch(e: Exception[1])
+   {
+      $errorThrown = $e.message->contains('SELECT AS STRUCT is not supported in Snowflake');
+   }
+   assert($errorThrown, 'Snowflake SQL generation should throw error for unsupported AS STRUCT feature');
+   
+   true;
+}
+
+function <<test.Test>> meta::pure::dsl::tests::testBigQueryExceptReplace(): Boolean[1]
+{
+   // Test SELECT * EXCEPT
+   let dfExcept = table('employees')->except(['id', 'created_at']);
+   let sqlExcept = $dfExcept->generateBigQuerySQL();
+   assert($sqlExcept->contains('* EXCEPT (id, created_at)'), 'BigQuery SQL should generate EXCEPT clause');
+   
+   // Test SELECT * REPLACE
+   let replacements = newMap([
+      pair('salary', literal(0)),
+      pair('age', ^FunctionExpression(functionName = 'CAST', parameters = [col('age'), literal('INT64')]))
+   ]);
+   let dfReplace = table('employees')->replace($replacements);
+   let sqlReplace = $dfReplace->generateBigQuerySQL();
+   assert($sqlReplace->contains('* REPLACE ('), 'BigQuery SQL should generate REPLACE clause');
+   assert($sqlReplace->contains('salary AS 0'), 'BigQuery SQL should replace salary with 0');
+   
+   // Test error handling in other databases
+   let errorThrown = false;
+   try
+   {
+      $dfExcept->generateDuckDBSQL();
+   }
+   catch(e: Exception[1])
+   {
+      $errorThrown = $e.message->contains('SELECT * EXCEPT is not supported in DuckDB');
+   }
+   assert($errorThrown, 'DuckDB SQL generation should throw error for unsupported EXCEPT feature');
+   
+   true;
+}
+
+function <<test.Test>> meta::pure::dsl::tests::testBigQueryDifferentialPrivacy(): Boolean[1]
+{
+   // Test WITH DIFFERENTIAL_PRIVACY
+   let df1 = table('employees')
+      ->select([~id, ~name, ~salary])
+      ->withDifferentialPrivacy(0.1, 0.01, 1.0);
+   
+   let sql1 = $df1->generateBigQuerySQL();
+   assert($sql1->contains('WITH DIFFERENTIAL_PRIVACY OPTIONS(epsilon=0.1, delta=0.01, kappa=1.0)'), 
+          'BigQuery SQL should generate DIFFERENTIAL_PRIVACY clause with epsilon, delta, and kappa');
+   
+   // Test WITH DIFFERENTIAL_PRIVACY with sensitivity
+   let df2 = table('employees')
+      ->select([~id, ~name, ~salary])
+      ->withDifferentialPrivacy(0.1, SensitivityType.SUM, 100.0);
+   
+   let sql2 = $df2->generateBigQuerySQL();
+   assert($sql2->contains('WITH DIFFERENTIAL_PRIVACY OPTIONS(epsilon=0.1, sensitivity_type=SUM, sensitivity_value=100.0)'), 
+          'BigQuery SQL should generate DIFFERENTIAL_PRIVACY clause with sensitivity');
+   
+   // Test error handling in other databases
+   let errorThrown = false;
+   try
+   {
+      $df1->generateSnowflakeSQL();
+   }
+   catch(e: Exception[1])
+   {
+      $errorThrown = $e.message->contains('WITH DIFFERENTIAL_PRIVACY is not supported in Snowflake');
+   }
+   assert($errorThrown, 'Snowflake SQL generation should throw error for unsupported DIFFERENTIAL_PRIVACY feature');
+   
+   true;
+}
+
+function <<test.Test>> meta::pure::dsl::tests::testBigQueryAggregationThreshold(): Boolean[1]
+{
+   // Test WITH AGGREGATION_THRESHOLD
+   let df1 = table('employees')
+      ->groupBy([~department])
+      ->extend([count(~id)->as('employee_count')])
+      ->withAggregationThreshold(10);
+   
+   let sql1 = $df1->generateBigQuerySQL();
+   assert($sql1->contains('WITH AGGREGATION_THRESHOLD 10'), 
+          'BigQuery SQL should generate AGGREGATION_THRESHOLD clause');
+   
+   // Test WITH AGGREGATION_THRESHOLD with replacement
+   let df2 = table('employees')
+      ->groupBy([~department])
+      ->extend([count(~id)->as('employee_count')])
+      ->withAggregationThreshold(10, 'NULL');
+   
+   let sql2 = $df2->generateBigQuerySQL();
+   assert($sql2->contains('WITH AGGREGATION_THRESHOLD 10 REPLACE WITH NULL'), 
+          'BigQuery SQL should generate AGGREGATION_THRESHOLD clause with replacement');
+   
+   // Test error handling in other databases
+   let errorThrown = false;
+   try
+   {
+      $df1->generateDuckDBSQL();
+   }
+   catch(e: Exception[1])
+   {
+      $errorThrown = $e.message->contains('WITH AGGREGATION_THRESHOLD is not supported in DuckDB');
+   }
+   assert($errorThrown, 'DuckDB SQL generation should throw error for unsupported AGGREGATION_THRESHOLD feature');
+   
+   true;
+}
+
+function <<test.Test>> meta::pure::dsl::tests::testBigQueryCombinedFeatures(): Boolean[1]
+{
+   // Test combining multiple BigQuery-specific features
+   let df = table('employees')
+      ->asStruct()
+      ->except(['created_at'])
+      ->replace(newMap([pair('salary', literal('REDACTED'))]))
+      ->withDifferentialPrivacy(0.1, 0.01, 1.0)
+      ->withAggregationThreshold(10);
+   
+   let sql = $df->generateBigQuerySQL();
+   
+   // Verify all features are included in the SQL
+   assert($sql->contains('SELECT AS STRUCT *'), 'Combined SQL should include AS STRUCT');
+   assert($sql->contains('EXCEPT (created_at)'), 'Combined SQL should include EXCEPT clause');
+   assert($sql->contains('REPLACE (salary AS REDACTED)'), 'Combined SQL should include REPLACE clause');
+   assert($sql->contains('WITH DIFFERENTIAL_PRIVACY'), 'Combined SQL should include DIFFERENTIAL_PRIVACY clause');
+   assert($sql->contains('WITH AGGREGATION_THRESHOLD'), 'Combined SQL should include AGGREGATION_THRESHOLD clause');
+   
+   true;
+}


### PR DESCRIPTION
# Implement Full SELECT Functionality for BigQuery

This PR implements full SELECT functionality for BigQuery in the legend-dataframe project, adding support for BigQuery-specific features including WITH DIFFERENTIAL_PRIVACY and WITH AGGREGATION_THRESHOLD clauses, SELECT AS STRUCT and SELECT AS VALUE statements, and SELECT * EXCEPT and SELECT * REPLACE syntax.

## Changes
- Updated DataFrame metamodel to include BigQuery-specific features
- Created BigQuery-specific metamodel classes for new features
- Updated BigQuery SQL generation with feature support and error handling
- Implemented BigQuery SELECT clause generation with STRUCT, VALUE, EXCEPT, and REPLACE support
- Added support for WITH DIFFERENTIAL_PRIVACY and WITH AGGREGATION_THRESHOLD clauses
- Updated error handling for BigQuery-specific features
- Added helper functions for creating BigQuery-specific features
- Created comprehensive tests for BigQuery-specific features
- Created example file demonstrating BigQuery-specific features

Link to Devin run: https://app.devin.ai/sessions/55f18f5a2aec4eaebe93abff37a48194
Requested by: neema.raphael@gs.com