### PR TITLE
Remove redundant window SQL generation function

### DIFF
--- a/src/main/resources/pure/dsl/snowflake/snowflake.pure
+++ b/src/main/resources/pure/dsl/snowflake/snowflake.pure
@@ -407,20 +407,6 @@ function <<access.private>> meta::pure::dsl::snowflake::generateSQLFromAggColSpe
    $funcName + '(' + $colName + ')';
 }
 
-function <<access.private>> meta::pure::dsl::snowflake::generateSQLFromWindowSpec(windowSpec: WindowSpec[1]): String[1]
-{
-   let partitionBy = if($windowSpec.partitionBy->isEmpty(), 
-                      '', 
-                      'PARTITION BY ' + $windowSpec.partitionBy->joinStrings(', '));
-   
-   let orderBy = if($windowSpec.orderBy->isEmpty(), 
-                   '', 
-                   if($partitionBy->isEmpty(), '', ' ') + 
-                   'ORDER BY ' + $windowSpec.orderBy->joinStrings(', '));
-   
-   $partitionBy + $orderBy;
-}
-
 // Add handling for _Window
 function meta::pure::dsl::snowflake::generateWindowSpecSQL(windowSpec: _Window<Any>[1]): String[1]
 {


### PR DESCRIPTION
This PR removes the redundant window SQL generation function from snowflake.pure that did not support frames, keeping only the more complete implementation with full frame support.

Link to Devin run: https://app.devin.ai/sessions/519b629242134e22918d4333208fc699
Requested by: Neema Raphael