### PR TITLE
Standardize feature support maps across database implementations

### DIFF
--- a/src/main/resources/pure/dsl/bigquery/bigquery.pure
+++ b/src/main/resources/pure/dsl/bigquery/bigquery.pure
@@ -17,26 +17,34 @@ import meta::pure::dsl::dataframe::metamodel::*;
 import meta::pure::dsl::dataframe::metamodel::column::*;
 
 // Main function to generate BigQuery SQL from a DataFrame
+// Helper function to expose feature map for testing
+function <<access.private>> meta::pure::dsl::bigquery::generateBigQuerySQL_featureMap(): Map<String, Boolean>[1]
+{
+   meta::pure::dsl::dataframe::createFeatureSupportMap(
+      meta::pure::dsl::dataframe::standardFeatureList()->map(f| 
+         if($f.first == 'PIVOT' || $f.first == 'UNPIVOT' || $f.first == 'LATERAL_JOIN' || 
+            $f.first == 'QUALIFY' || $f.first == 'STRUCT' || $f.first == 'VALUE' || 
+            $f.first == 'EXCEPT' || $f.first == 'REPLACE' || $f.first == 'DIFFERENTIAL_PRIVACY' || 
+            $f.first == 'AGGREGATION_THRESHOLD',
+            pair($f.first, true),
+            $f)
+      )
+   );
+}
+
 function meta::pure::dsl::bigquery::generateBigQuerySQL(df: DataFrame[1]): String[1]
 {
    // Check for unsupported features using standardized error handling
-   let supportedFeatures = meta::pure::dsl::dataframe::createFeatureSupportMap([
-      pair('PIVOT', true),
-      pair('UNPIVOT', true),
-      pair('MATCH_RECOGNIZE', false),
-      pair('LATERAL_JOIN', true),
-      pair('AT', false),
-      pair('CHANGES', false),
-      pair('CONNECT_BY', false),
-      pair('SAMPLE', false),
-      pair('QUALIFY', true),
-      pair('STRUCT', true),
-      pair('VALUE', true),
-      pair('EXCEPT', true),
-      pair('REPLACE', true),
-      pair('DIFFERENTIAL_PRIVACY', true),
-      pair('AGGREGATION_THRESHOLD', true)
-   ]);
+   let supportedFeatures = meta::pure::dsl::dataframe::createFeatureSupportMap(
+      meta::pure::dsl::dataframe::standardFeatureList()->map(f| 
+         if($f.first == 'PIVOT' || $f.first == 'UNPIVOT' || $f.first == 'LATERAL_JOIN' || 
+            $f.first == 'QUALIFY' || $f.first == 'STRUCT' || $f.first == 'VALUE' || 
+            $f.first == 'EXCEPT' || $f.first == 'REPLACE' || $f.first == 'DIFFERENTIAL_PRIVACY' || 
+            $f.first == 'AGGREGATION_THRESHOLD',
+            pair($f.first, true),
+            $f)
+      )
+   );
    
    meta::pure::dsl::dataframe::checkUnsupportedFeatures($df, 'BigQuery', $supportedFeatures);
    

--- a/src/main/resources/pure/dsl/dataframe/errorHandling.pure
+++ b/src/main/resources/pure/dsl/dataframe/errorHandling.pure
@@ -84,3 +84,25 @@ function meta::pure::dsl::dataframe::createFeatureSupportMap(features: Pair<Stri
 {
    newMap($features);
 }
+
+// Standard list of all supported features across all databases
+function meta::pure::dsl::dataframe::standardFeatureList(): Pair<String, Boolean>[*]
+{
+   [
+      pair('PIVOT', false),
+      pair('UNPIVOT', false),
+      pair('MATCH_RECOGNIZE', false),
+      pair('LATERAL_JOIN', false),
+      pair('AT', false),
+      pair('CHANGES', false),
+      pair('CONNECT_BY', false),
+      pair('SAMPLE', false),
+      pair('QUALIFY', false),
+      pair('STRUCT', false),
+      pair('VALUE', false),
+      pair('EXCEPT', false),
+      pair('REPLACE', false),
+      pair('DIFFERENTIAL_PRIVACY', false),
+      pair('AGGREGATION_THRESHOLD', false)
+   ]
+}

--- a/src/main/resources/pure/dsl/duckdb/duckdb.pure
+++ b/src/main/resources/pure/dsl/duckdb/duckdb.pure
@@ -22,21 +22,29 @@ import meta::pure::dsl::duckdb::*;
  * This module provides functions to convert DataFrame objects to DuckDB SQL syntax
  */
 
+// Helper function to expose feature map for testing
+function <<access.private>> meta::pure::dsl::duckdb::generateDuckDBSQL_featureMap(): Map<String, Boolean>[1]
+{
+   meta::pure::dsl::dataframe::createFeatureSupportMap(
+      meta::pure::dsl::dataframe::standardFeatureList()->map(f| 
+         if($f.first == 'SAMPLE' || $f.first == 'QUALIFY',
+            pair($f.first, true),
+            $f)
+      )
+   );
+}
+
 // Main function to generate DuckDB SQL from a DataFrame
 function meta::pure::dsl::duckdb::generateDuckDBSQL(df: DataFrame[1]): String[1]
 {
    // Check for unsupported features using standardized error handling
-   let supportedFeatures = meta::pure::dsl::dataframe::createFeatureSupportMap([
-      pair('PIVOT', false),
-      pair('UNPIVOT', false),
-      pair('MATCH_RECOGNIZE', false),
-      pair('LATERAL_JOIN', false),
-      pair('AT', false),
-      pair('CHANGES', false),
-      pair('CONNECT_BY', false),
-      pair('SAMPLE', true),
-      pair('QUALIFY', true)
-   ]);
+   let supportedFeatures = meta::pure::dsl::dataframe::createFeatureSupportMap(
+      meta::pure::dsl::dataframe::standardFeatureList()->map(f| 
+         if($f.first == 'SAMPLE' || $f.first == 'QUALIFY',
+            pair($f.first, true),
+            $f)
+      )
+   );
    
    meta::pure::dsl::dataframe::checkUnsupportedFeatures($df, 'DuckDB', $supportedFeatures);
    

--- a/src/main/resources/pure/dsl/postgres/postgres.pure
+++ b/src/main/resources/pure/dsl/postgres/postgres.pure
@@ -22,21 +22,29 @@ import meta::pure::dsl::postgres::*;
  * This module provides functions to convert DataFrame objects to PostgreSQL SQL syntax
  */
 
+// Helper function to expose feature map for testing
+function <<access.private>> meta::pure::dsl::postgres::generatePostgresSQL_featureMap(): Map<String, Boolean>[1]
+{
+   meta::pure::dsl::dataframe::createFeatureSupportMap(
+      meta::pure::dsl::dataframe::standardFeatureList()->map(f| 
+         if($f.first == 'LATERAL_JOIN',
+            pair($f.first, true),
+            $f)
+      )
+   );
+}
+
 // Main function to generate PostgreSQL SQL from a DataFrame
 function meta::pure::dsl::postgres::generatePostgresSQL(df: DataFrame[1]): String[1]
 {
    // Define feature support for PostgreSQL
-   let supportedFeatures = meta::pure::dsl::dataframe::createFeatureSupportMap([
-      pair('PIVOT', false),
-      pair('UNPIVOT', false),
-      pair('MATCH_RECOGNIZE', false),
-      pair('LATERAL_JOIN', true),
-      pair('AT', false),
-      pair('CHANGES', false),
-      pair('CONNECT_BY', false),
-      pair('SAMPLE', false),
-      pair('QUALIFY', false)
-   ]);
+   let supportedFeatures = meta::pure::dsl::dataframe::createFeatureSupportMap(
+      meta::pure::dsl::dataframe::standardFeatureList()->map(f| 
+         if($f.first == 'LATERAL_JOIN',
+            pair($f.first, true),
+            $f)
+      )
+   );
    
    meta::pure::dsl::dataframe::checkUnsupportedFeatures($df, 'PostgreSQL', $supportedFeatures);
    

--- a/src/main/resources/pure/dsl/redshift/redshift.pure
+++ b/src/main/resources/pure/dsl/redshift/redshift.pure
@@ -22,27 +22,29 @@ import meta::pure::dsl::redshift::*;
  * This module provides functions to convert DataFrame objects to Redshift SQL syntax
  */
 
+// Helper function to expose feature map for testing
+function <<access.private>> meta::pure::dsl::redshift::generateRedshiftSQL_featureMap(): Map<String, Boolean>[1]
+{
+   meta::pure::dsl::dataframe::createFeatureSupportMap(
+      meta::pure::dsl::dataframe::standardFeatureList()->map(f| 
+         if($f.first == 'LATERAL_JOIN' || $f.first == 'CONNECT_BY' || $f.first == 'QUALIFY',
+            pair($f.first, true),
+            $f)
+      )
+   );
+}
+
 // Main function to generate Redshift SQL from a DataFrame
 function meta::pure::dsl::redshift::generateRedshiftSQL(df: DataFrame[1]): String[1]
 {
    // Check for unsupported features using standardized error handling
-   let supportedFeatures = meta::pure::dsl::dataframe::createFeatureSupportMap([
-      pair('PIVOT', false),
-      pair('UNPIVOT', false),
-      pair('MATCH_RECOGNIZE', false),
-      pair('LATERAL_JOIN', true),
-      pair('AT', false),
-      pair('CHANGES', false),
-      pair('CONNECT_BY', true),
-      pair('SAMPLE', false),
-      pair('QUALIFY', true),
-      pair('STRUCT', false),
-      pair('VALUE', false),
-      pair('EXCEPT', false),
-      pair('REPLACE', false),
-      pair('DIFFERENTIAL_PRIVACY', false),
-      pair('AGGREGATION_THRESHOLD', false)
-   ]);
+   let supportedFeatures = meta::pure::dsl::dataframe::createFeatureSupportMap(
+      meta::pure::dsl::dataframe::standardFeatureList()->map(f| 
+         if($f.first == 'LATERAL_JOIN' || $f.first == 'CONNECT_BY' || $f.first == 'QUALIFY',
+            pair($f.first, true),
+            $f)
+      )
+   );
    
    meta::pure::dsl::dataframe::checkUnsupportedFeatures($df, 'Redshift', $supportedFeatures);
    

--- a/src/main/resources/pure/dsl/snowflake/snowflake.pure
+++ b/src/main/resources/pure/dsl/snowflake/snowflake.pure
@@ -22,21 +22,34 @@ import meta::pure::dsl::snowflake::*;
  * This module provides functions to convert DataFrame objects to Snowflake SQL syntax
  */
 
+// Helper function to expose feature map for testing
+function <<access.private>> meta::pure::dsl::snowflake::generateSnowflakeSQL_featureMap(): Map<String, Boolean>[1]
+{
+   meta::pure::dsl::dataframe::createFeatureSupportMap(
+      meta::pure::dsl::dataframe::standardFeatureList()->map(f| 
+         if($f.first == 'PIVOT' || $f.first == 'UNPIVOT' || $f.first == 'MATCH_RECOGNIZE' || 
+            $f.first == 'LATERAL_JOIN' || $f.first == 'AT' || $f.first == 'CHANGES' || 
+            $f.first == 'CONNECT_BY' || $f.first == 'SAMPLE' || $f.first == 'QUALIFY',
+            pair($f.first, true),
+            $f)
+      )
+   );
+}
+
 // Main function to generate Snowflake SQL from a DataFrame
 function meta::pure::dsl::snowflake::generateSnowflakeSQL(df: DataFrame[1]): String[1]
 {
+
    // Snowflake supports all features - use standardized feature support map
-   let supportedFeatures = meta::pure::dsl::dataframe::createFeatureSupportMap([
-      pair('PIVOT', true),
-      pair('UNPIVOT', true),
-      pair('MATCH_RECOGNIZE', true),
-      pair('LATERAL_JOIN', true),
-      pair('AT', true),
-      pair('CHANGES', true),
-      pair('CONNECT_BY', true),
-      pair('SAMPLE', true),
-      pair('QUALIFY', true)
-   ]);
+   let supportedFeatures = meta::pure::dsl::dataframe::createFeatureSupportMap(
+      meta::pure::dsl::dataframe::standardFeatureList()->map(f| 
+         if($f.first == 'PIVOT' || $f.first == 'UNPIVOT' || $f.first == 'MATCH_RECOGNIZE' || 
+            $f.first == 'LATERAL_JOIN' || $f.first == 'AT' || $f.first == 'CHANGES' || 
+            $f.first == 'CONNECT_BY' || $f.first == 'SAMPLE' || $f.first == 'QUALIFY',
+            pair($f.first, true),
+            $f)
+      )
+   );
    
    // No errors should be thrown since all features are supported
    meta::pure::dsl::dataframe::checkUnsupportedFeatures($df, 'Snowflake', $supportedFeatures);

--- a/src/test/resources/pure/dsl/tests/feature_support_tests.pure
+++ b/src/test/resources/pure/dsl/tests/feature_support_tests.pure
@@ -1,0 +1,38 @@
+// Copyright 2025 Neema Raphael
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::dsl::dataframe::*;
+import meta::pure::dsl::dataframe::metamodel::*;
+
+function <<meta::pure::profiles::test.Test>> {meta.pure.profiles.test.AlloyOnly} meta::pure::dsl::tests::testFeatureSupportConsistency(): Boolean[1]
+{
+   // Get the standard feature list
+   let standardFeatures = meta::pure::dsl::dataframe::standardFeatureList()->map(f| $f.first);
+   
+   // Verify that each database implementation includes all standard features
+   let snowflakeFeatures = meta::pure::dsl::snowflake::generateSnowflakeSQL_featureMap();
+   let redshiftFeatures = meta::pure::dsl::redshift::generateRedshiftSQL_featureMap();
+   let bigqueryFeatures = meta::pure::dsl::bigquery::generateBigQuerySQL_featureMap();
+   let duckdbFeatures = meta::pure::dsl::duckdb::generateDuckDBSQL_featureMap();
+   let postgresFeatures = meta::pure::dsl::postgres::generatePostgresSQL_featureMap();
+   
+   // Check that all standard features are included in each implementation
+   assertEquals($standardFeatures->size(), $snowflakeFeatures->keys()->size());
+   assertEquals($standardFeatures->size(), $redshiftFeatures->keys()->size());
+   assertEquals($standardFeatures->size(), $bigqueryFeatures->keys()->size());
+   assertEquals($standardFeatures->size(), $duckdbFeatures->keys()->size());
+   assertEquals($standardFeatures->size(), $postgresFeatures->keys()->size());
+   
+   true;
+}


### PR DESCRIPTION
This PR implements a common feature list for all database implementations to ensure consistency and easier maintenance.

Added a standardFeatureList() function in errorHandling.pure that all database implementations now reference, with each only overriding the features they support.

[Link to Devin run](https://app.devin.ai/sessions/519b629242134e22918d4333208fc699)
Requested by: Neema Raphael