### PR TITLE
Consolidate Redshift window functions

### DIFF
--- a/src/main/resources/pure/dsl/redshift/redshift.pure
+++ b/src/main/resources/pure/dsl/redshift/redshift.pure
@@ -205,42 +205,12 @@ function <<access.private>> meta::pure::dsl::redshift::generateRedshiftFunction(
 function <<access.private>> meta::pure::dsl::redshift::generateRedshiftWindowFunction(func: WindowFunction[1]): String[1]
 {
    // Use central implementation
-   meta::pure::dsl::dataframe::generateWindowFunctionSQL($func, {e | generateRedshiftExpression($e)}, {w | generateRedshiftWindow($w)});
+   meta::pure::dsl::dataframe::generateWindowFunctionSQL($func, {e | generateRedshiftExpression($e)}, {w | meta::pure::dsl::dataframe::generateWindowSpecSQL($w, {e | generateRedshiftExpression($e)})});
 }
 
-// Generate SQL for window specification
-function <<access.private>> meta::pure::dsl::redshift::generateRedshiftWindow(window: Window[1]): String[1]
-{
-   let partitionBy = if($window.partitionBy->isEmpty(), 
-                       '', 
-                       'PARTITION BY ' + $window.partitionBy->map(e | $e->generateRedshiftExpression())->joinStrings(', '));
-   
-   let orderBy = if($window.orderBy->isEmpty(), 
-                    '', 
-                    if($partitionBy->isEmpty(), '', ' ') + 
-                    'ORDER BY ' + $window.orderBy->map(o | $o.expression->generateRedshiftExpression() + ' ' + $o.direction->toString())->joinStrings(', '));
-   
-   let frame = if($window.frameType->isEmpty(), 
-                 '', 
-                 if($partitionBy->isEmpty() && $orderBy->isEmpty(), '', ' ') + 
-                 $window.frameType->toOne()->toString() + ' BETWEEN ' + 
-                 $window.frameStart->toOne()->generateRedshiftWindowFrameBound() + ' AND ' + 
-                 $window.frameEnd->toOne()->generateRedshiftWindowFrameBound());
-   
-   $partitionBy + $orderBy + $frame;
-}
+// Window specification is now handled by the common implementation in windowFunctions.pure
 
-// Generate SQL for window frame bounds
-function <<access.private>> meta::pure::dsl::redshift::generateRedshiftWindowFrameBound(bound: WindowFrameBound[1]): String[1]
-{
-   $bound.type->match([
-      WindowFrameBoundType.UNBOUNDED_PRECEDING | 'UNBOUNDED PRECEDING',
-      WindowFrameBoundType.PRECEDING | $bound.offset->toOne()->toString() + ' PRECEDING',
-      WindowFrameBoundType.CURRENT_ROW | 'CURRENT ROW',
-      WindowFrameBoundType.FOLLOWING | $bound.offset->toOne()->toString() + ' FOLLOWING',
-      WindowFrameBoundType.UNBOUNDED_FOLLOWING | 'UNBOUNDED FOLLOWING'
-   ])
-}
+// Window frame bounds are now handled by the common implementation in windowFunctions.pure
 
 // Generate SQL for literal values
 function <<access.private>> meta::pure::dsl::redshift::generateRedshiftLiteral(value: Any[1]): String[1]

--- a/src/main/resources/pure/dsl/redshift/redshift.pure
+++ b/src/main/resources/pure/dsl/redshift/redshift.pure
@@ -204,27 +204,8 @@ function <<access.private>> meta::pure::dsl::redshift::generateRedshiftFunction(
 // Generate SQL for window functions
 function <<access.private>> meta::pure::dsl::redshift::generateRedshiftWindowFunction(func: WindowFunction[1]): String[1]
 {
-   let functionCall = $func->match([
-      r: RowNumberFunction[1] | 'ROW_NUMBER()',
-      r: RankFunction[1] | 'RANK()',
-      d: DenseRankFunction[1] | 'DENSE_RANK()',
-      l: LeadLagFunction[1] | $l.functionName->toUpperCase() + '(' + 
-                                $l.parameters->map(p | $p->generateRedshiftExpression())->joinStrings(', ') +
-                                if($l.offset->isNotEmpty(), ', ' + $l.offset->toOne()->generateRedshiftExpression(), '') + 
-                                if($l.defaultValue->isNotEmpty(), ', ' + $l.defaultValue->toOne()->generateRedshiftExpression(), '') +
-                                ')',
-      f: FirstLastValueFunction[1] | $f.functionName->toUpperCase() + '(' + 
-                                     $f.parameters->map(p | $p->generateRedshiftExpression())->joinStrings(', ') + 
-                                     ')' + if($f.ignoreNulls == true, ' IGNORE NULLS', ''),
-      a: AggregateWindowFunction[1] | $a.functionName->toUpperCase() + '(' + 
-                                      $a.parameters->map(p | $p->generateRedshiftExpression())->joinStrings(', ') + 
-                                      ')',
-      w: WindowFunction[1] | $w.functionName + '(' + 
-                            $w.parameters->map(p | $p->generateRedshiftExpression())->joinStrings(', ') + 
-                            ')'
-   ]);
-   
-   $functionCall + ' OVER(' + $func.window->generateRedshiftWindow() + ')';
+   // Use central implementation
+   meta::pure::dsl::dataframe::generateWindowFunctionSQL($func, {e | generateRedshiftExpression($e)}, {w | generateRedshiftWindow($w)});
 }
 
 // Generate SQL for window specification


### PR DESCRIPTION
Updated Redshift window functions to use the common implementation from windowFunctions.pure, following the same pattern used for other database implementations. Also removed redundant generateRedshiftWindow and generateRedshiftWindowFrameBound functions since we can use the common implementations.

Link to Devin run: https://app.devin.ai/sessions/519b629242134e22918d4333208fc699
Requested by: Neema Raphael