### PR TITLE
Consolidate window functions across all database implementations

### DIFF
--- a/src/main/resources/pure/dsl/bigquery/bigquery.pure
+++ b/src/main/resources/pure/dsl/bigquery/bigquery.pure
@@ -257,34 +257,10 @@ function <<access.private>> meta::pure::dsl::bigquery::generateBigQueryCase(case
 // Generate BigQuery window function
 function <<access.private>> meta::pure::dsl::bigquery::generateBigQueryWindowFunction(windowFunc: WindowFunctionColumn[1]): String[1]
 {
+   // Use common implementation from windowFunctions.pure
    $windowFunc.function->generateBigQueryExpression() + 
    ' OVER (' + 
-   if($windowFunc.partitionBy->isEmpty(), 
-      '', 
-      'PARTITION BY ' + $windowFunc.partitionBy->map(p | $p->generateBigQueryExpression())->joinStrings(', ')) + 
-   if($windowFunc.orderBy->isEmpty(), 
-      '', 
-      if($windowFunc.partitionBy->isEmpty(), '', ' ') + 
-      'ORDER BY ' + $windowFunc.orderBy->map(o | 
-         $o.column->generateBigQueryExpression() + 
-         if($o.direction == SortDirection.ASC, '', ' DESC') + 
-         if($o.nulls == NullsOrder.FIRST, ' NULLS FIRST', if($o.nulls == NullsOrder.LAST, ' NULLS LAST', ''))
-      )->joinStrings(', ')) + 
-   if($windowFunc.frameClause->isEmpty(), 
-      '', 
-      if($windowFunc.partitionBy->isEmpty() && $windowFunc.orderBy->isEmpty(), '', ' ') + 
-      $windowFunc.frameClause->toOne().type->toString() + ' ' + 
-      if($windowFunc.frameClause->toOne().start == FrameBoundary.UNBOUNDED_PRECEDING, 
-         'UNBOUNDED PRECEDING', 
-         if($windowFunc.frameClause->toOne().start == FrameBoundary.CURRENT_ROW, 
-            'CURRENT ROW', 
-            $windowFunc.frameClause->toOne().startOffset->toOne()->toString() + ' PRECEDING')) + 
-      ' AND ' + 
-      if($windowFunc.frameClause->toOne().end == FrameBoundary.UNBOUNDED_FOLLOWING, 
-         'UNBOUNDED FOLLOWING', 
-         if($windowFunc.frameClause->toOne().end == FrameBoundary.CURRENT_ROW, 
-            'CURRENT ROW', 
-            $windowFunc.frameClause->toOne().endOffset->toOne()->toString() + ' FOLLOWING'))) + 
+   meta::pure::dsl::dataframe::generateWindowSpecFromWindowFunctionColumn($windowFunc, {e | generateBigQueryExpression($e)}) +
    ')';
 }
 
@@ -308,38 +284,7 @@ function <<access.private>> meta::pure::dsl::bigquery::generateBigQueryUnpivot(u
    ')';
 }
 
-// Generate SQL for window functions (with WindowFunction parameter)
-function <<access.private>> meta::pure::dsl::bigquery::generateBigQueryWindowFunctionWithWindow(func: WindowFunction[1]): String[1]
-{
-   meta::pure::dsl::dataframe::generateWindowFunctionSQL($func, {e | generateBigQueryExpression($e)}, {w | generateBigQueryWindowSpec($w)});
-}
-
-// Generate SQL for window specifications
-function <<access.private>> meta::pure::dsl::bigquery::generateBigQueryWindowSpec(windowSpec: Window[1]): String[1]
-{
-   meta::pure::dsl::dataframe::generateWindowSpecSQL($windowSpec, {e | generateBigQueryExpression($e)});
-}
-
-// Generate SQL for _Window specifications
-function <<access.private>> meta::pure::dsl::bigquery::generateWindowSpecSQL(windowSpec: _Window<Any>[1]): String[1]
-{
-   // Use central implementation
-   meta::pure::dsl::dataframe::generateWindowSpecSQL($windowSpec, {e | generateBigQueryExpression($e)});
-}
-
-// Generate SQL for window frames
-function <<access.private>> meta::pure::dsl::bigquery::generateFrameSQL(frame: Frame[1]): String[1]
-{
-   // Use central implementation
-   meta::pure::dsl::dataframe::generateFrameSQL($frame);
-}
-
-// Generate SQL for frame values
-function <<access.private>> meta::pure::dsl::bigquery::generateFrameValueSQL(frameValue: FrameValue[1]): String[1]
-{
-   // Use central implementation
-   meta::pure::dsl::dataframe::generateFrameValueSQL($frameValue);
-}
+// Window functions are now handled by the common implementation in windowFunctions.pure
 
 // Generate SQL for a data source
 function <<access.private>> meta::pure::dsl::bigquery::generateBigQueryDataSource(source: DataSource[1]): String[1]

--- a/src/main/resources/pure/dsl/databricks/databricks.pure
+++ b/src/main/resources/pure/dsl/databricks/databricks.pure
@@ -220,34 +220,10 @@ function <<access.private>> meta::pure::dsl::databricks::generateDatabricksCase(
 // Generate Databricks window function
 function <<access.private>> meta::pure::dsl::databricks::generateDatabricksWindowFunction(windowFunc: WindowFunctionColumn[1]): String[1]
 {
+   // Use common implementation from windowFunctions.pure
    $windowFunc.function->generateDatabricksExpression() + 
    ' OVER (' + 
-   if($windowFunc.partitionBy->isEmpty(), 
-      '', 
-      'PARTITION BY ' + $windowFunc.partitionBy->map(p | $p->generateDatabricksExpression())->joinStrings(', ')) + 
-   if($windowFunc.orderBy->isEmpty(), 
-      '', 
-      if($windowFunc.partitionBy->isEmpty(), '', ' ') + 
-      'ORDER BY ' + $windowFunc.orderBy->map(o | 
-         $o.column->generateDatabricksExpression() + 
-         if($o.direction == SortDirection.ASC, '', ' DESC') + 
-         if($o.nulls == NullsOrder.FIRST, ' NULLS FIRST', if($o.nulls == NullsOrder.LAST, ' NULLS LAST', ''))
-      )->joinStrings(', ')) + 
-   if($windowFunc.frameClause->isEmpty(), 
-      '', 
-      if($windowFunc.partitionBy->isEmpty() && $windowFunc.orderBy->isEmpty(), '', ' ') + 
-      $windowFunc.frameClause->toOne().type->toString() + ' ' + 
-      if($windowFunc.frameClause->toOne().start == FrameBoundary.UNBOUNDED_PRECEDING, 
-         'UNBOUNDED PRECEDING', 
-         if($windowFunc.frameClause->toOne().start == FrameBoundary.CURRENT_ROW, 
-            'CURRENT ROW', 
-            $windowFunc.frameClause->toOne().startOffset->toOne()->toString() + ' PRECEDING')) + 
-      ' AND ' + 
-      if($windowFunc.frameClause->toOne().end == FrameBoundary.UNBOUNDED_FOLLOWING, 
-         'UNBOUNDED FOLLOWING', 
-         if($windowFunc.frameClause->toOne().end == FrameBoundary.CURRENT_ROW, 
-            'CURRENT ROW', 
-            $windowFunc.frameClause->toOne().endOffset->toOne()->toString() + ' FOLLOWING'))) + 
+   meta::pure::dsl::dataframe::generateWindowSpecFromWindowFunctionColumn($windowFunc, {e | generateDatabricksExpression($e)}) +
    ')';
 }
 

--- a/src/main/resources/pure/dsl/dataframe/windowFunctions.pure
+++ b/src/main/resources/pure/dsl/dataframe/windowFunctions.pure
@@ -108,3 +108,38 @@ function meta::pure::dsl::dataframe::generateFrameValueSQL(frameValue: FrameValu
         )
    );
 }
+
+// Helper function to generate window spec from WindowFunctionColumn
+function meta::pure::dsl::dataframe::generateWindowSpecFromWindowFunctionColumn(windowFunc: WindowFunctionColumn[1], expressionGenerator: Function<{Expression[1]->String[1]}>[1]): String[1]
+{
+   let partitionBy = if($windowFunc.partitionBy->isEmpty(), 
+                     '', 
+                     'PARTITION BY ' + $windowFunc.partitionBy->map(p | $expressionGenerator->eval($p))->joinStrings(', '));
+   
+   let orderBy = if($windowFunc.orderBy->isEmpty(), 
+                 '', 
+                 if($partitionBy->isEmpty(), '', ' ') + 
+                 'ORDER BY ' + $windowFunc.orderBy->map(o | 
+                    $expressionGenerator->eval($o.column) + 
+                    if($o.direction == SortDirection.ASC, '', ' DESC') + 
+                    if($o.nulls == NullsOrder.FIRST, ' NULLS FIRST', if($o.nulls == NullsOrder.LAST, ' NULLS LAST', ''))
+                 )->joinStrings(', '));
+   
+   let frame = if($windowFunc.frameClause->isEmpty(), 
+               '', 
+               if($partitionBy->isEmpty() && $orderBy->isEmpty(), '', ' ') + 
+               $windowFunc.frameClause->toOne().type->toString() + ' ' + 
+               if($windowFunc.frameClause->toOne().start == FrameBoundary.UNBOUNDED_PRECEDING, 
+                  'UNBOUNDED PRECEDING', 
+                  if($windowFunc.frameClause->toOne().start == FrameBoundary.CURRENT_ROW, 
+                     'CURRENT ROW', 
+                     $windowFunc.frameClause->toOne().startOffset->toOne()->toString() + ' PRECEDING')) + 
+               ' AND ' + 
+               if($windowFunc.frameClause->toOne().end == FrameBoundary.UNBOUNDED_FOLLOWING, 
+                  'UNBOUNDED FOLLOWING', 
+                  if($windowFunc.frameClause->toOne().end == FrameBoundary.CURRENT_ROW, 
+                     'CURRENT ROW', 
+                     $windowFunc.frameClause->toOne().endOffset->toOne()->toString() + ' FOLLOWING')));
+   
+   $partitionBy + $orderBy + $frame;
+}

--- a/src/main/resources/pure/dsl/duckdb/duckdb.pure
+++ b/src/main/resources/pure/dsl/duckdb/duckdb.pure
@@ -214,62 +214,18 @@ function <<access.private>> meta::pure::dsl::duckdb::generateDuckDBFunction(func
 // Generate SQL for window functions
 function <<access.private>> meta::pure::dsl::duckdb::generateDuckDBWindowFunction(func: WindowFunction[1]): String[1]
 {
-   let functionCall = $func->match([
-      r: RowNumberFunction[1] | 'ROW_NUMBER()',
-      r: RankFunction[1] | 'RANK()',
-      d: DenseRankFunction[1] | 'DENSE_RANK()',
-      l: LeadLagFunction[1] | $l.functionName->toUpperCase() + '(' + 
-                                $l.parameters->map(p | $p->generateDuckDBExpression())->joinStrings(', ') +
-                                if($l.offset->isNotEmpty(), ', ' + $l.offset->toOne()->generateDuckDBExpression(), '') + 
-                                if($l.defaultValue->isNotEmpty(), ', ' + $l.defaultValue->toOne()->generateDuckDBExpression(), '') +
-                                ')',
-      f: FirstLastValueFunction[1] | $f.functionName->toUpperCase() + '(' + 
-                                      $f.parameters->map(p | $p->generateDuckDBExpression())->joinStrings(', ') + 
-                                      ')' + if($f.ignoreNulls == true, ' IGNORE NULLS', ''),
-      a: AggregateWindowFunction[1] | $a.functionName->toUpperCase() + '(' + 
-                                      $a.parameters->map(p | $p->generateDuckDBExpression())->joinStrings(', ') + 
-                                      ')',
-      w: WindowFunction[1] | $w.functionName + '(' + 
-                              $w.parameters->map(p | $p->generateDuckDBExpression())->joinStrings(', ') + 
-                              ')'
-   ]);
-   
-   $functionCall + ' OVER(' + $func.window->generateDuckDBWindow() + ')';
+   // Use common implementation from windowFunctions.pure
+   meta::pure::dsl::dataframe::generateWindowFunctionSQL($func, {e | generateDuckDBExpression($e)}, {w | generateDuckDBWindow($w)});
 }
 
 // Generate SQL for window specification
 function <<access.private>> meta::pure::dsl::duckdb::generateDuckDBWindow(window: Window[1]): String[1]
 {
-   let partitionBy = if($window.partitionBy->isEmpty(), 
-                       '', 
-                       'PARTITION BY ' + $window.partitionBy->map(e | $e->generateDuckDBExpression())->joinStrings(', '));
-   
-   let orderBy = if($window.orderBy->isEmpty(), 
-                    '', 
-                    if($partitionBy->isEmpty(), '', ' ') + 
-                    'ORDER BY ' + $window.orderBy->map(o | $o.expression->generateDuckDBExpression() + ' ' + $o.direction->toString())->joinStrings(', '));
-   
-   let frame = if($window.frameType->isEmpty(), 
-                 '', 
-                 if($partitionBy->isEmpty() && $orderBy->isEmpty(), '', ' ') + 
-                 $window.frameType->toOne()->toString() + ' BETWEEN ' + 
-                 $window.frameStart->toOne()->generateDuckDBWindowFrameBound() + ' AND ' + 
-                 $window.frameEnd->toOne()->generateDuckDBWindowFrameBound());
-   
-   $partitionBy + $orderBy + $frame;
+   // Use common implementation from windowFunctions.pure
+   meta::pure::dsl::dataframe::generateWindowSpecSQL($window, {e | generateDuckDBExpression($e)});
 }
 
-// Generate SQL for window frame bounds
-function <<access.private>> meta::pure::dsl::duckdb::generateDuckDBWindowFrameBound(bound: WindowFrameBound[1]): String[1]
-{
-   $bound.type->match([
-      WindowFrameBoundType.UNBOUNDED_PRECEDING | 'UNBOUNDED PRECEDING',
-      WindowFrameBoundType.PRECEDING | $bound.offset->toOne()->toString() + ' PRECEDING',
-      WindowFrameBoundType.CURRENT_ROW | 'CURRENT ROW',
-      WindowFrameBoundType.FOLLOWING | $bound.offset->toOne()->toString() + ' FOLLOWING',
-      WindowFrameBoundType.UNBOUNDED_FOLLOWING | 'UNBOUNDED FOLLOWING'
-   ])
-}
+// Window frame bounds are now handled by the common implementation in windowFunctions.pure
 
 // Generate SQL for binary operators
 function <<access.private>> meta::pure::dsl::duckdb::generateDuckDBBinaryOperator(op: BinaryOperator[1]): String[1]

--- a/src/main/resources/pure/dsl/postgres/postgres.pure
+++ b/src/main/resources/pure/dsl/postgres/postgres.pure
@@ -230,10 +230,9 @@ function <<access.private>> meta::pure::dsl::postgres::generatePostgresFunction(
          let window = $func.parameters->last()->cast(@Window);
          let params = $func.parameters->excluding($func.parameters->last());
          
+         // Use common implementation from windowFunctions.pure
          $funcName + '(' + $params->map(p | $p->generatePostgresExpression())->joinStrings(', ') + ') OVER(' +
-         if($window.partition->isEmpty(), '', 'PARTITION BY ' + $window.partition->joinStrings(', ')) +
-         if($window.sortInfo->isEmpty(), '', if($window.partition->isEmpty(), '', ' ') + 'ORDER BY ' + $window.sortInfo->map(s | $s.column + if($s.direction == SortDirection.ASC, ' ASC', ' DESC'))->joinStrings(', ')) +
-         if($window.frame->isEmpty(), '', ' ' + $window.frame->toOne()->generatePostgresFrame()) +
+         meta::pure::dsl::dataframe::generateWindowSpecSQL($window, {e | generatePostgresExpression($e)}) +
          ')',
          // Standard function call
          $funcName + '(' + $func.parameters->map(p | $p->generatePostgresExpression())->joinStrings(', ') + ')'
@@ -241,21 +240,7 @@ function <<access.private>> meta::pure::dsl::postgres::generatePostgresFunction(
    )
 }
 
-// Generate frame for window functions
-function <<access.private>> meta::pure::dsl::postgres::generatePostgresFrame(frame: Frame[1]): String[1]
-{
-   $frame.type->toString() + ' ' + 
-   if($frame.start->isEmpty() && $frame.end->isEmpty(),
-      'UNBOUNDED PRECEDING AND CURRENT ROW',
-      if($frame.start->isNotEmpty() && $frame.end->isEmpty(),
-         $frame.start->toOne() + ' AND CURRENT ROW',
-         if($frame.start->isEmpty() && $frame.end->isNotEmpty(),
-            'UNBOUNDED PRECEDING AND ' + $frame.end->toOne(),
-            $frame.start->toOne() + ' AND ' + $frame.end->toOne()
-         )
-      )
-   )
-}
+// Window frames are now handled by the common implementation in windowFunctions.pure
 
 // Generate binary operation
 function <<access.private>> meta::pure::dsl::postgres::generatePostgresBinaryOp(op: BinaryOperation[1]): String[1]

--- a/src/main/resources/pure/dsl/snowflake/snowflake.pure
+++ b/src/main/resources/pure/dsl/snowflake/snowflake.pure
@@ -287,62 +287,18 @@ function <<access.private>> meta::pure::dsl::snowflake::generateSnowflakeFunctio
 // Generate SQL for window functions
 function <<access.private>> meta::pure::dsl::snowflake::generateSnowflakeWindowFunction(func: WindowFunction[1]): String[1]
 {
-   let functionCall = $func->match([
-      r: RowNumberFunction[1] | 'ROW_NUMBER()',
-      r: RankFunction[1] | 'RANK()',
-      d: DenseRankFunction[1] | 'DENSE_RANK()',
-      l: LeadLagFunction[1] | $l.functionName->toUpperCase() + '(' + 
-                                $l.parameters->map(p | $p->generateSnowflakeExpression())->joinStrings(', ') +
-                                if($l.offset->isNotEmpty(), ', ' + $l.offset->toOne()->generateSnowflakeExpression(), '') + 
-                                if($l.defaultValue->isNotEmpty(), ', ' + $l.defaultValue->toOne()->generateSnowflakeExpression(), '') +
-                                ')',
-      f: FirstLastValueFunction[1] | $f.functionName->toUpperCase() + '(' + 
-                                      $f.parameters->map(p | $p->generateSnowflakeExpression())->joinStrings(', ') + 
-                                      ')' + if($f.ignoreNulls == true, ' IGNORE NULLS', ''),
-      a: AggregateWindowFunction[1] | $a.functionName->toUpperCase() + '(' + 
-                                      $a.parameters->map(p | $p->generateSnowflakeExpression())->joinStrings(', ') + 
-                                      ')',
-      w: WindowFunction[1] | $w.functionName + '(' + 
-                              $w.parameters->map(p | $p->generateSnowflakeExpression())->joinStrings(', ') + 
-                              ')'
-   ]);
-   
-   $functionCall + ' OVER(' + $func.window->generateSnowflakeWindow() + ')';
+   // Use common implementation from windowFunctions.pure
+   meta::pure::dsl::dataframe::generateWindowFunctionSQL($func, {e | generateSnowflakeExpression($e)}, {w | generateSnowflakeWindow($w)});
 }
 
 // Generate SQL for window specification
 function <<access.private>> meta::pure::dsl::snowflake::generateSnowflakeWindow(window: Window[1]): String[1]
 {
-   let partitionBy = if($window.partitionBy->isEmpty(), 
-                       '', 
-                       'PARTITION BY ' + $window.partitionBy->map(e | $e->generateSnowflakeExpression())->joinStrings(', '));
-   
-   let orderBy = if($window.orderBy->isEmpty(), 
-                    '', 
-                    if($partitionBy->isEmpty(), '', ' ') + 
-                    'ORDER BY ' + $window.orderBy->map(o | $o.expression->generateSnowflakeExpression() + ' ' + $o.direction->toString())->joinStrings(', '));
-   
-   let frame = if($window.frameType->isEmpty(), 
-                 '', 
-                 if($partitionBy->isEmpty() && $orderBy->isEmpty(), '', ' ') + 
-                 $window.frameType->toOne()->toString() + ' BETWEEN ' + 
-                 $window.frameStart->toOne()->generateSnowflakeWindowFrameBound() + ' AND ' + 
-                 $window.frameEnd->toOne()->generateSnowflakeWindowFrameBound());
-   
-   $partitionBy + $orderBy + $frame;
+   // Use common implementation from windowFunctions.pure
+   meta::pure::dsl::dataframe::generateWindowSpecSQL($window, {e | generateSnowflakeExpression($e)});
 }
 
-// Generate SQL for window frame bounds
-function <<access.private>> meta::pure::dsl::snowflake::generateSnowflakeWindowFrameBound(bound: WindowFrameBound[1]): String[1]
-{
-   $bound.type->match([
-      WindowFrameBoundType.UNBOUNDED_PRECEDING | 'UNBOUNDED PRECEDING',
-      WindowFrameBoundType.PRECEDING | $bound.offset->toOne()->toString() + ' PRECEDING',
-      WindowFrameBoundType.CURRENT_ROW | 'CURRENT ROW',
-      WindowFrameBoundType.FOLLOWING | $bound.offset->toOne()->toString() + ' FOLLOWING',
-      WindowFrameBoundType.UNBOUNDED_FOLLOWING | 'UNBOUNDED FOLLOWING'
-   ])
-}
+// Window frame bounds are now handled by the common implementation in windowFunctions.pure
 
 // Generate SQL for binary operators
 function <<access.private>> meta::pure::dsl::snowflake::generateSnowflakeBinaryOperator(op: BinaryOperator[1]): String[1]


### PR DESCRIPTION
Consolidated window functions for BigQuery, Databricks, DuckDB, Postgres, and Snowflake to use the common implementations from windowFunctions.pure, following the same pattern used for Redshift.

Link to Devin run: https://app.devin.ai/sessions/519b629242134e22918d4333208fc699
Requested by: Neema Raphael