### PR TITLE
Consolidate DuckDB and Snowflake window functions

### DIFF
--- a/src/main/resources/pure/dsl/duckdb/duckdb.pure
+++ b/src/main/resources/pure/dsl/duckdb/duckdb.pure
@@ -214,62 +214,18 @@ function <<access.private>> meta::pure::dsl::duckdb::generateDuckDBFunction(func
 // Generate SQL for window functions
 function <<access.private>> meta::pure::dsl::duckdb::generateDuckDBWindowFunction(func: WindowFunction[1]): String[1]
 {
-   let functionCall = $func->match([
-      r: RowNumberFunction[1] | 'ROW_NUMBER()',
-      r: RankFunction[1] | 'RANK()',
-      d: DenseRankFunction[1] | 'DENSE_RANK()',
-      l: LeadLagFunction[1] | $l.functionName->toUpperCase() + '(' + 
-                                $l.parameters->map(p | $p->generateDuckDBExpression())->joinStrings(', ') +
-                                if($l.offset->isNotEmpty(), ', ' + $l.offset->toOne()->generateDuckDBExpression(), '') + 
-                                if($l.defaultValue->isNotEmpty(), ', ' + $l.defaultValue->toOne()->generateDuckDBExpression(), '') +
-                                ')',
-      f: FirstLastValueFunction[1] | $f.functionName->toUpperCase() + '(' + 
-                                      $f.parameters->map(p | $p->generateDuckDBExpression())->joinStrings(', ') + 
-                                      ')' + if($f.ignoreNulls == true, ' IGNORE NULLS', ''),
-      a: AggregateWindowFunction[1] | $a.functionName->toUpperCase() + '(' + 
-                                      $a.parameters->map(p | $p->generateDuckDBExpression())->joinStrings(', ') + 
-                                      ')',
-      w: WindowFunction[1] | $w.functionName + '(' + 
-                              $w.parameters->map(p | $p->generateDuckDBExpression())->joinStrings(', ') + 
-                              ')'
-   ]);
-   
-   $functionCall + ' OVER(' + $func.window->generateDuckDBWindow() + ')';
+   // Use common implementation from windowFunctions.pure
+   meta::pure::dsl::dataframe::generateWindowFunctionSQL($func, {e | generateDuckDBExpression($e)}, {w | generateDuckDBWindow($w)});
 }
 
 // Generate SQL for window specification
 function <<access.private>> meta::pure::dsl::duckdb::generateDuckDBWindow(window: Window[1]): String[1]
 {
-   let partitionBy = if($window.partitionBy->isEmpty(), 
-                       '', 
-                       'PARTITION BY ' + $window.partitionBy->map(e | $e->generateDuckDBExpression())->joinStrings(', '));
-   
-   let orderBy = if($window.orderBy->isEmpty(), 
-                    '', 
-                    if($partitionBy->isEmpty(), '', ' ') + 
-                    'ORDER BY ' + $window.orderBy->map(o | $o.expression->generateDuckDBExpression() + ' ' + $o.direction->toString())->joinStrings(', '));
-   
-   let frame = if($window.frameType->isEmpty(), 
-                 '', 
-                 if($partitionBy->isEmpty() && $orderBy->isEmpty(), '', ' ') + 
-                 $window.frameType->toOne()->toString() + ' BETWEEN ' + 
-                 $window.frameStart->toOne()->generateDuckDBWindowFrameBound() + ' AND ' + 
-                 $window.frameEnd->toOne()->generateDuckDBWindowFrameBound());
-   
-   $partitionBy + $orderBy + $frame;
+   // Use common implementation from windowFunctions.pure
+   meta::pure::dsl::dataframe::generateWindowSpecSQL($window, {e | generateDuckDBExpression($e)});
 }
 
-// Generate SQL for window frame bounds
-function <<access.private>> meta::pure::dsl::duckdb::generateDuckDBWindowFrameBound(bound: WindowFrameBound[1]): String[1]
-{
-   $bound.type->match([
-      WindowFrameBoundType.UNBOUNDED_PRECEDING | 'UNBOUNDED PRECEDING',
-      WindowFrameBoundType.PRECEDING | $bound.offset->toOne()->toString() + ' PRECEDING',
-      WindowFrameBoundType.CURRENT_ROW | 'CURRENT ROW',
-      WindowFrameBoundType.FOLLOWING | $bound.offset->toOne()->toString() + ' FOLLOWING',
-      WindowFrameBoundType.UNBOUNDED_FOLLOWING | 'UNBOUNDED FOLLOWING'
-   ])
-}
+// Window frame bounds are now handled by the common implementation in windowFunctions.pure
 
 // Generate SQL for binary operators
 function <<access.private>> meta::pure::dsl::duckdb::generateDuckDBBinaryOperator(op: BinaryOperator[1]): String[1]

--- a/src/main/resources/pure/dsl/snowflake/snowflake.pure
+++ b/src/main/resources/pure/dsl/snowflake/snowflake.pure
@@ -287,62 +287,18 @@ function <<access.private>> meta::pure::dsl::snowflake::generateSnowflakeFunctio
 // Generate SQL for window functions
 function <<access.private>> meta::pure::dsl::snowflake::generateSnowflakeWindowFunction(func: WindowFunction[1]): String[1]
 {
-   let functionCall = $func->match([
-      r: RowNumberFunction[1] | 'ROW_NUMBER()',
-      r: RankFunction[1] | 'RANK()',
-      d: DenseRankFunction[1] | 'DENSE_RANK()',
-      l: LeadLagFunction[1] | $l.functionName->toUpperCase() + '(' + 
-                                $l.parameters->map(p | $p->generateSnowflakeExpression())->joinStrings(', ') +
-                                if($l.offset->isNotEmpty(), ', ' + $l.offset->toOne()->generateSnowflakeExpression(), '') + 
-                                if($l.defaultValue->isNotEmpty(), ', ' + $l.defaultValue->toOne()->generateSnowflakeExpression(), '') +
-                                ')',
-      f: FirstLastValueFunction[1] | $f.functionName->toUpperCase() + '(' + 
-                                      $f.parameters->map(p | $p->generateSnowflakeExpression())->joinStrings(', ') + 
-                                      ')' + if($f.ignoreNulls == true, ' IGNORE NULLS', ''),
-      a: AggregateWindowFunction[1] | $a.functionName->toUpperCase() + '(' + 
-                                      $a.parameters->map(p | $p->generateSnowflakeExpression())->joinStrings(', ') + 
-                                      ')',
-      w: WindowFunction[1] | $w.functionName + '(' + 
-                              $w.parameters->map(p | $p->generateSnowflakeExpression())->joinStrings(', ') + 
-                              ')'
-   ]);
-   
-   $functionCall + ' OVER(' + $func.window->generateSnowflakeWindow() + ')';
+   // Use common implementation from windowFunctions.pure
+   meta::pure::dsl::dataframe::generateWindowFunctionSQL($func, {e | generateSnowflakeExpression($e)}, {w | generateSnowflakeWindow($w)});
 }
 
 // Generate SQL for window specification
 function <<access.private>> meta::pure::dsl::snowflake::generateSnowflakeWindow(window: Window[1]): String[1]
 {
-   let partitionBy = if($window.partitionBy->isEmpty(), 
-                       '', 
-                       'PARTITION BY ' + $window.partitionBy->map(e | $e->generateSnowflakeExpression())->joinStrings(', '));
-   
-   let orderBy = if($window.orderBy->isEmpty(), 
-                    '', 
-                    if($partitionBy->isEmpty(), '', ' ') + 
-                    'ORDER BY ' + $window.orderBy->map(o | $o.expression->generateSnowflakeExpression() + ' ' + $o.direction->toString())->joinStrings(', '));
-   
-   let frame = if($window.frameType->isEmpty(), 
-                 '', 
-                 if($partitionBy->isEmpty() && $orderBy->isEmpty(), '', ' ') + 
-                 $window.frameType->toOne()->toString() + ' BETWEEN ' + 
-                 $window.frameStart->toOne()->generateSnowflakeWindowFrameBound() + ' AND ' + 
-                 $window.frameEnd->toOne()->generateSnowflakeWindowFrameBound());
-   
-   $partitionBy + $orderBy + $frame;
+   // Use common implementation from windowFunctions.pure
+   meta::pure::dsl::dataframe::generateWindowSpecSQL($window, {e | generateSnowflakeExpression($e)});
 }
 
-// Generate SQL for window frame bounds
-function <<access.private>> meta::pure::dsl::snowflake::generateSnowflakeWindowFrameBound(bound: WindowFrameBound[1]): String[1]
-{
-   $bound.type->match([
-      WindowFrameBoundType.UNBOUNDED_PRECEDING | 'UNBOUNDED PRECEDING',
-      WindowFrameBoundType.PRECEDING | $bound.offset->toOne()->toString() + ' PRECEDING',
-      WindowFrameBoundType.CURRENT_ROW | 'CURRENT ROW',
-      WindowFrameBoundType.FOLLOWING | $bound.offset->toOne()->toString() + ' FOLLOWING',
-      WindowFrameBoundType.UNBOUNDED_FOLLOWING | 'UNBOUNDED FOLLOWING'
-   ])
-}
+// Window frame bounds are now handled by the common implementation in windowFunctions.pure
 
 // Generate SQL for binary operators
 function <<access.private>> meta::pure::dsl::snowflake::generateSnowflakeBinaryOperator(op: BinaryOperator[1]): String[1]


### PR DESCRIPTION
Consolidated window functions for DuckDB and Snowflake to use the common implementations from windowFunctions.pure, following the same pattern used for Redshift.

Link to Devin run: https://app.devin.ai/sessions/519b629242134e22918d4333208fc699
Requested by: Neema Raphael