### PR TITLE
Remove _Window class and update Window to include Frame property

### DIFF
--- a/src/main/resources/pure/dsl/bigquery/bigquery.pure
+++ b/src/main/resources/pure/dsl/bigquery/bigquery.pure
@@ -287,12 +287,7 @@ function <<access.private>> meta::pure::dsl::bigquery::generateBigQueryWindowSpe
    meta::pure::dsl::dataframe::generateWindowSpecSQL($windowSpec, {e | generateBigQueryExpression($e)});
 }
 
-// Generate SQL for _Window specifications
-function <<access.private>> meta::pure::dsl::bigquery::generateWindowSpecSQL(windowSpec: _Window<Any>[1]): String[1]
-{
-   // Use central implementation
-   meta::pure::dsl::dataframe::generateWindowSpecSQL($windowSpec, {e | generateBigQueryExpression($e)});
-}
+
 
 // Generate SQL for window frames
 function <<access.private>> meta::pure::dsl::bigquery::generateFrameSQL(frame: Frame[1]): String[1]

--- a/src/main/resources/pure/dsl/dataframe/dataframe.pure
+++ b/src/main/resources/pure/dsl/dataframe/dataframe.pure
@@ -296,9 +296,7 @@ Class meta::pure::dsl::dataframe::metamodel::Window
 {
    partitionBy : Expression[*];
    orderBy : OrderByClause[*];
-   frameType : WindowFrameType[0..1];
-   frameStart : WindowFrameBound[0..1];
-   frameEnd : WindowFrameBound[0..1];
+   frame : Frame[0..1];
 }
 
 Enum meta::pure::dsl::dataframe::metamodel::WindowFrameType
@@ -824,63 +822,24 @@ function meta::pure::dsl::dataframe::over(expr: Expression[1], window: Window[1]
    }
 }
 
-// Adapter function for window functions
-function meta::pure::dsl::dataframe::over(expr: Expression[1], window: _Window<Any>[1]): WindowFunction[1]
+// Window function creation helper
+function meta::pure::dsl::dataframe::over(expr: Expression[1], window: Window[1]): WindowFunction[1]
 {
-   // Convert _Window to Window
-   let w = ^Window(
-      partitionBy = $window.partition->map(p | col($p)),
-      orderBy = $window.sortInfo->map(s | ^OrderByClause(
-         expression = col($s.column), 
-         direction = $s.direction == meta::pure::dsl::dataframe::metamodel::window::SortDirection.ASC ? 
-                     meta::pure::dsl::dataframe::metamodel::SortDirection.ASC : 
-                     meta::pure::dsl::dataframe::metamodel::SortDirection.DESC
-      ))
-   );
-   
-   // Apply frame if present
-   let framedWindow = if($window.frame->isEmpty(), 
-      | $w, 
-      | if($window.frame->toOne()->instanceOf(Rows),
-          | rowsBetween($w, 
-               toWindowFrameBound($window.frame->toOne().offsetFrom), 
-               toWindowFrameBound($window.frame->toOne().offsetTo)),
-          | rangeBetween($w, 
-               toWindowFrameBound($window.frame->toOne().offsetFrom), 
-               toWindowFrameBound($window.frame->toOne().offsetTo))
-        )
-   );
-   
-   over($expr, $framedWindow);
-}
-
-function meta::pure::dsl::dataframe::toWindowFrameBound(frameValue: FrameValue[1]): WindowFrameBound[1]
-{
-   if($frameValue->instanceOf(UnboundedFrameValue),
-      | unboundedPreceding(),
-      | if($frameValue->instanceOf(FrameIntValue),
-           | let value = $frameValue->cast(@FrameIntValue).value;
-             if($value == 0,
-                | currentRow(),
-                | if($value > 0,
-                     | following($value),
-                     | preceding($value * -1)
-                  )
-             );,
-           | unboundedPreceding() // Default case
-        )
+   ^WindowFunction(
+      function = $expr,
+      window = $window
    );
 }
 
-// SortInfo helper functions
-function meta::pure::dsl::dataframe::asc<T>(col: ColSpec<T>[1]): SortInfo<T>[1]
+// OrderBy helper functions
+function meta::pure::dsl::dataframe::asc<T>(col: ColSpec<T>[1]): OrderByClause[1]
 {
-   ^SortInfo<T>(column = $col.name, direction = meta::pure::dsl::dataframe::metamodel::window::SortDirection.ASC);
+   ^OrderByClause(expression = col($col.name), direction = SortDirection.ASC);
 }
 
-function meta::pure::dsl::dataframe::desc<T>(col: ColSpec<T>[1]): SortInfo<T>[1]
+function meta::pure::dsl::dataframe::desc<T>(col: ColSpec<T>[1]): OrderByClause[1]
 {
-   ^SortInfo<T>(column = $col.name, direction = meta::pure::dsl::dataframe::metamodel::window::SortDirection.DESC);
+   ^OrderByClause(expression = col($col.name), direction = SortDirection.DESC);
 }
 
 function meta::pure::dsl::dataframe::getFunctionName(expr: Expression[1]): String[1]
@@ -898,14 +857,43 @@ function meta::pure::dsl::dataframe::getFunctionParameters(expr: Expression[1]):
 }
 
 // Type-safe over functions for window operations
+
 function 
    <<functionType.NormalizeRequiredFunction,
    PCT.function>>
-   meta::pure::dsl::dataframe::over<T>(cols: String[*], sortInfo: SortInfo<(?:?)⊆T>[*], frame: Frame[0..1]): _Window<T>[1]
+   meta::pure::dsl::dataframe::over<T>(cols: ColSpec<(?:?)⊆T>[1]): Window[1]
 {
-   ^_Window<T>(
-      partition = $cols,
-      sortInfo = $sortInfo,
+   ^Window(
+      partitionBy = [col($cols.name)]
+   );
+}
+
+function 
+   <<functionType.NormalizeRequiredFunction,
+   PCT.function>>
+   meta::pure::dsl::dataframe::over<T>(cols: ColSpecArray<(?:?)⊆T>[1]): Window[1]
+{
+   ^Window(
+      partitionBy = $cols.names->map(c | col($c))
+   );
+}
+
+function 
+   <<functionType.NormalizeRequiredFunction,
+   PCT.function>>
+   meta::pure::dsl::dataframe::over<T>(orderBy: OrderByClause[*]): Window[1]
+{
+   ^Window(
+      orderBy = $orderBy
+   );
+}
+
+function 
+   <<functionType.NormalizeRequiredFunction,
+   PCT.function>>
+   meta::pure::dsl::dataframe::over<T>(frame: Frame[1]): Window[1]
+{
+   ^Window(
       frame = $frame
    );
 }
@@ -913,69 +901,34 @@ function
 function 
    <<functionType.NormalizeRequiredFunction,
    PCT.function>>
-   meta::pure::dsl::dataframe::over<T>(cols: ColSpec<(?:?)⊆T>[1]): _Window<T>[1]
+   meta::pure::dsl::dataframe::over<T>(cols: ColSpec<(?:?)⊆T>[1], orderBy: OrderByClause[*]): Window[1]
 {
-   ^_Window<T>(
-      partition = [$cols.name]
+   ^Window(
+      partitionBy = [col($cols.name)],
+      orderBy = $orderBy
    );
 }
 
 function 
    <<functionType.NormalizeRequiredFunction,
    PCT.function>>
-   meta::pure::dsl::dataframe::over<T>(cols: ColSpecArray<(?:?)⊆T>[1]): _Window<T>[1]
+   meta::pure::dsl::dataframe::over<T>(cols: ColSpecArray<(?:?)⊆T>[1], orderBy: OrderByClause[*]): Window[1]
 {
-   ^_Window<T>(
-      partition = $cols.names
+   ^Window(
+      partitionBy = $cols.names->map(c | col($c)),
+      orderBy = $orderBy
    );
 }
 
 function 
    <<functionType.NormalizeRequiredFunction,
    PCT.function>>
-   meta::pure::dsl::dataframe::over<T>(sortInfo: SortInfo<(?:?)⊆T>[*]): _Window<T>[1]
+   meta::pure::dsl::dataframe::over<T>(cols: ColSpec<(?:?)⊆T>[1], frame: Frame[1]): Window[1]
 {
-   over([], $sortInfo, []);
-}
-
-function 
-   <<functionType.NormalizeRequiredFunction,
-   PCT.function>>
-   meta::pure::dsl::dataframe::over<T>(frame: Frame[1]): _Window<T>[1]
-{
-   over([], [], $frame);
-}
-
-function 
-   <<functionType.NormalizeRequiredFunction,
-   PCT.function>>
-   meta::pure::dsl::dataframe::over<T>(cols: ColSpec<(?:?)⊆T>[1], sortInfo: SortInfo<(?:?)⊆T>[*]): _Window<T>[1]
-{
-   over([$cols.name], $sortInfo, []);
-}
-
-function 
-   <<functionType.NormalizeRequiredFunction,
-   PCT.function>>
-   meta::pure::dsl::dataframe::over<T>(cols: ColSpecArray<(?:?)⊆T>[1], sortInfo: SortInfo<(?:?)⊆T>[*]): _Window<T>[1]
-{
-   over($cols.names, $sortInfo, []);
-}
-
-function 
-   <<functionType.NormalizeRequiredFunction,
-   PCT.function>>
-   meta::pure::dsl::dataframe::over<T>(cols: ColSpec<(?:?)⊆T>[1], frame: Frame[1]): _Window<T>[1]
-{
-   over([$cols.name], [], $frame);
-}
-
-function 
-   <<functionType.NormalizeRequiredFunction,
-   PCT.function>>
-   meta::pure::dsl::dataframe::over<T>(sortInfo: SortInfo<(?:?)⊆T>[*], frame: Frame[1]): _Window<T>[1]
-{
-   over([], $sortInfo, $frame);
+   ^Window(
+      partitionBy = [col($cols.name)],
+      frame = $frame
+   );
 }
 
 function meta::pure::dsl::dataframe::partitionBy(columns: Expression[*]): Window[1]
@@ -1005,12 +958,20 @@ function meta::pure::dsl::dataframe::qualify<T>(df: DataFrame<T>[1], condition: 
 
 function meta::pure::dsl::dataframe::rowsBetween(window: Window[1], start: WindowFrameBound[1], end: WindowFrameBound[1]): Window[1]
 {
-   ^$window(frameType = WindowFrameType.ROWS, frameStart = $start, frameEnd = $end);
+   let frame = ^Rows(
+      offsetFrom = toFrameValue($start),
+      offsetTo = toFrameValue($end)
+   );
+   ^$window(frame = $frame);
 }
 
 function meta::pure::dsl::dataframe::rangeBetween(window: Window[1], start: WindowFrameBound[1], end: WindowFrameBound[1]): Window[1]
 {
-   ^$window(frameType = WindowFrameType.RANGE, frameStart = $start, frameEnd = $end);
+   let frame = ^Range(
+      offsetFrom = toFrameValue($start),
+      offsetTo = toFrameValue($end)
+   );
+   ^$window(frame = $frame);
 }
 
 function meta::pure::dsl::dataframe::unboundedPreceding(): WindowFrameBound[1]
@@ -1037,6 +998,19 @@ function meta::pure::dsl::dataframe::following(offset: Integer[1]): WindowFrameB
 {
    ^WindowFrameBound(type = WindowFrameBoundType.FOLLOWING, offset = $offset);
 }
+
+// Helper function to convert WindowFrameBound to FrameValue
+function meta::pure::dsl::dataframe::toFrameValue(bound: WindowFrameBound[1]): FrameValue[1]
+{
+   $bound.type->match([
+      WindowFrameBoundType.UNBOUNDED_PRECEDING | ^UnboundedFrameValue(),
+      WindowFrameBoundType.UNBOUNDED_FOLLOWING | ^UnboundedFrameValue(),
+      WindowFrameBoundType.CURRENT_ROW | ^FrameIntValue(value = 0),
+      WindowFrameBoundType.PRECEDING | ^FrameIntValue(value = -1 * $bound.offset->toOne()),
+      WindowFrameBoundType.FOLLOWING | ^FrameIntValue(value = $bound.offset->toOne())
+   ]);
+}
+
 
 // Window function factory functions
 function meta::pure::dsl::dataframe::rowNumber(): FunctionExpression[1]

--- a/src/main/resources/pure/dsl/dataframe/metamodel/window.pure
+++ b/src/main/resources/pure/dsl/dataframe/metamodel/window.pure
@@ -17,19 +17,6 @@ import meta::pure::dsl::dataframe::metamodel::*;
 import meta::pure::dsl::dataframe::metamodel::window::*;
 import meta::pure::dsl::dataframe::metamodel::frame::*;
 
-Class meta::pure::dsl::dataframe::metamodel::window::_Window<T>
-{
-   partition: String[*];
-   sortInfo: SortInfo[*];
-   frame: Frame[0..1];
-}
-
-Class meta::pure::dsl::dataframe::metamodel::window::SortInfo<T>
-{
-   column: String[1];
-   direction: SortDirection[1];
-}
-
 Enum meta::pure::dsl::dataframe::metamodel::window::SortDirection
 {
    ASC,

--- a/src/main/resources/pure/dsl/dataframe/windowFunctions.pure
+++ b/src/main/resources/pure/dsl/dataframe/windowFunctions.pure
@@ -55,22 +55,6 @@ function meta::pure::dsl::dataframe::generateWindowSpecSQL(windowSpec: Window[1]
                  'ORDER BY ' + $windowSpec.orderBy->map(o | $expressionGenerator->eval($o.expression) + 
                      if($o.direction == SortDirection.ASC, '', ' DESC'))->joinStrings(', '));
    
-   $partitionBy + $orderBy;
-}
-
-// Standard _Window specification generation
-function meta::pure::dsl::dataframe::generateWindowSpecSQL(windowSpec: _Window<Any>[1], expressionGenerator: Function<{Expression[1]->String[1]}>[1]): String[1]
-{
-   let partitionBy = if($windowSpec.partition->isEmpty(), 
-                     '', 
-                     'PARTITION BY ' + $windowSpec.partition->joinStrings(', '));
-   
-   let orderBy = if($windowSpec.sortInfo->isEmpty(), 
-                 '', 
-                 if($partitionBy->isEmpty(), '', ' ') + 
-                 'ORDER BY ' + $windowSpec.sortInfo->map(s | $s.column + 
-                     if($s.direction == SortDirection.ASC, '', ' DESC'))->joinStrings(', '));
-   
    let frame = if($windowSpec.frame->isEmpty(), 
                '', 
                if($partitionBy->isEmpty() && $orderBy->isEmpty(), '', ' ') + 
@@ -78,6 +62,8 @@ function meta::pure::dsl::dataframe::generateWindowSpecSQL(windowSpec: _Window<A
    
    $partitionBy + $orderBy + $frame;
 }
+
+
 
 // Standard frame generation
 function meta::pure::dsl::dataframe::generateFrameSQL(frame: Frame[1]): String[1]

--- a/src/main/resources/pure/dsl/duckdb/duckdb.pure
+++ b/src/main/resources/pure/dsl/duckdb/duckdb.pure
@@ -318,12 +318,7 @@ function <<access.private>> meta::pure::dsl::duckdb::generateSQLFromWindowSpec(w
    $partitionBy + $orderBy;
 }
 
-// Add handling for _Window
-function meta::pure::dsl::duckdb::generateWindowSpecSQL(windowSpec: _Window<Any>[1]): String[1]
-{
-   // Use central implementation
-   meta::pure::dsl::dataframe::generateWindowSpecSQL($windowSpec, {e | generateDuckDBExpression($e)});
-}
+
 
 function meta::pure::dsl::duckdb::generateFrameSQL(frame: Frame[1]): String[1]
 {

--- a/src/main/resources/pure/dsl/postgres/postgres.pure
+++ b/src/main/resources/pure/dsl/postgres/postgres.pure
@@ -231,9 +231,7 @@ function <<access.private>> meta::pure::dsl::postgres::generatePostgresFunction(
          let params = $func.parameters->excluding($func.parameters->last());
          
          $funcName + '(' + $params->map(p | $p->generatePostgresExpression())->joinStrings(', ') + ') OVER(' +
-         if($window.partition->isEmpty(), '', 'PARTITION BY ' + $window.partition->joinStrings(', ')) +
-         if($window.sortInfo->isEmpty(), '', if($window.partition->isEmpty(), '', ' ') + 'ORDER BY ' + $window.sortInfo->map(s | $s.column + if($s.direction == SortDirection.ASC, ' ASC', ' DESC'))->joinStrings(', ')) +
-         if($window.frame->isEmpty(), '', ' ' + $window.frame->toOne()->generatePostgresFrame()) +
+         meta::pure::dsl::dataframe::generateWindowSpecSQL($window, {e | generatePostgresExpression($e)}) +
          ')',
          // Standard function call
          $funcName + '(' + $func.parameters->map(p | $p->generatePostgresExpression())->joinStrings(', ') + ')'

--- a/src/main/resources/pure/dsl/snowflake/snowflake.pure
+++ b/src/main/resources/pure/dsl/snowflake/snowflake.pure
@@ -376,12 +376,7 @@ function <<access.private>> meta::pure::dsl::snowflake::generateSQLFromAggColSpe
    $funcName + '(' + $colName + ')';
 }
 
-// Add handling for _Window
-function meta::pure::dsl::snowflake::generateWindowSpecSQL(windowSpec: _Window<Any>[1]): String[1]
-{
-   // Use central implementation
-   meta::pure::dsl::dataframe::generateWindowSpecSQL($windowSpec, {e | generateSnowflakeExpression($e)});
-}
+
 
 function meta::pure::dsl::snowflake::generateFrameSQL(frame: Frame[1]): String[1]
 {


### PR DESCRIPTION
This PR consolidates window classes by removing _Window and SortInfo classes and updating Window to include a Frame property. All usages of _Window and SortInfo have been updated to use Window directly.

Link to Devin run: https://app.devin.ai/sessions/519b629242134e22918d4333208fc699
Requested by: Neema.Raphael@gs.com