### PR TITLE
Move over functions from dataframe.pure to over.pure and orderby functions to orderby.pure

### DIFF
--- a/src/main/resources/pure/dsl/dataframe/dataframe.pure
+++ b/src/main/resources/pure/dsl/dataframe/dataframe.pure
@@ -15,6 +15,8 @@
 import meta::pure::dsl::dataframe::*;
 import meta::pure::dsl::dataframe::metamodel::*;
 import meta::pure::dsl::dataframe::metamodel::column::*;
+import meta::pure::dsl::dataframe::over::*;
+import meta::pure::dsl::dataframe::orderby::*;
 
 /**
  * Core DataFrame DSL for modeling SQL SELECT statements
@@ -777,70 +779,9 @@ function meta::pure::dsl::dataframe::desc(expr: Expression[1]): OrderByClause[1]
    ^OrderByClause(expression = $expr, direction = SortDirection.DESC)
 }
 
-// Window function helper functions
-// Original over function for backward compatibility
-function meta::pure::dsl::dataframe::over(expr: Expression[1], window: Window[1]): WindowFunction[1]
-{
-   let functionName = $expr->getFunctionName();
-   
-   if($functionName == 'row_number')
-   {
-      ^RowNumberFunction(functionName = $functionName, parameters = [], window = $window);
-   }
-   else if($functionName == 'rank')
-   {
-      ^RankFunction(functionName = $functionName, parameters = [], window = $window);
-   }
-   else if($functionName == 'dense_rank')
-   {
-      ^DenseRankFunction(functionName = $functionName, parameters = [], window = $window);
-   }
-   else if($functionName == 'lead' || $functionName == 'lag')
-   {
-      let params = $expr->getFunctionParameters();
-      let valueExpr = $params->at(0);
-      let offset = if($params->size() >= 2, |$params->at(1), |^LiteralExpression(value = 1));
-      let defaultValue = if($params->size() >= 3, |$params->at(2), |^LiteralExpression(value = null));
-      
-      ^LeadLagFunction(functionName = $functionName, parameters = [$valueExpr], window = $window, offset = $offset, defaultValue = $defaultValue);
-   }
-   else if($functionName == 'first_value' || $functionName == 'last_value')
-   {
-      let params = $expr->getFunctionParameters();
-      let valueExpr = $params->at(0);
-      
-      ^FirstLastValueFunction(functionName = $functionName, parameters = [$valueExpr], window = $window);
-   }
-   else
-   {
-      // Default to aggregate window function for sum, avg, min, max, count, etc.
-      let params = if($expr->instanceOf(FunctionExpression), 
-                     |$expr->cast(@FunctionExpression).parameters, 
-                     |[$expr]);
-      
-      ^AggregateWindowFunction(functionName = $functionName, parameters = $params, window = $window);
-   }
-}
 
-// Window function creation helper
-function meta::pure::dsl::dataframe::over(expr: Expression[1], window: Window[1]): WindowFunction[1]
-{
-   ^WindowFunction(
-      function = $expr,
-      window = $window
-   );
-}
 
-// OrderBy helper functions
-function meta::pure::dsl::dataframe::asc<T>(col: ColSpec<T>[1]): OrderByClause[1]
-{
-   ^OrderByClause(expression = col($col.name), direction = SortDirection.ASC);
-}
 
-function meta::pure::dsl::dataframe::desc<T>(col: ColSpec<T>[1]): OrderByClause[1]
-{
-   ^OrderByClause(expression = col($col.name), direction = SortDirection.DESC);
-}
 
 function meta::pure::dsl::dataframe::getFunctionName(expr: Expression[1]): String[1]
 {
@@ -856,99 +797,7 @@ function meta::pure::dsl::dataframe::getFunctionParameters(expr: Expression[1]):
       |[]);
 }
 
-// Type-safe over functions for window operations
 
-function 
-   <<functionType.NormalizeRequiredFunction,
-   PCT.function>>
-   meta::pure::dsl::dataframe::over<T>(cols: ColSpec<(?:?)⊆T>[1]): Window[1]
-{
-   ^Window(
-      partitionBy = [col($cols.name)]
-   );
-}
-
-function 
-   <<functionType.NormalizeRequiredFunction,
-   PCT.function>>
-   meta::pure::dsl::dataframe::over<T>(cols: ColSpecArray<(?:?)⊆T>[1]): Window[1]
-{
-   ^Window(
-      partitionBy = $cols.names->map(c | col($c))
-   );
-}
-
-function 
-   <<functionType.NormalizeRequiredFunction,
-   PCT.function>>
-   meta::pure::dsl::dataframe::over<T>(orderBy: OrderByClause[*]): Window[1]
-{
-   ^Window(
-      orderBy = $orderBy
-   );
-}
-
-function 
-   <<functionType.NormalizeRequiredFunction,
-   PCT.function>>
-   meta::pure::dsl::dataframe::over<T>(frame: Frame[1]): Window[1]
-{
-   ^Window(
-      frame = $frame
-   );
-}
-
-function 
-   <<functionType.NormalizeRequiredFunction,
-   PCT.function>>
-   meta::pure::dsl::dataframe::over<T>(cols: ColSpec<(?:?)⊆T>[1], orderBy: OrderByClause[*]): Window[1]
-{
-   ^Window(
-      partitionBy = [col($cols.name)],
-      orderBy = $orderBy
-   );
-}
-
-function 
-   <<functionType.NormalizeRequiredFunction,
-   PCT.function>>
-   meta::pure::dsl::dataframe::over<T>(cols: ColSpecArray<(?:?)⊆T>[1], orderBy: OrderByClause[*]): Window[1]
-{
-   ^Window(
-      partitionBy = $cols.names->map(c | col($c)),
-      orderBy = $orderBy
-   );
-}
-
-function 
-   <<functionType.NormalizeRequiredFunction,
-   PCT.function>>
-   meta::pure::dsl::dataframe::over<T>(cols: ColSpec<(?:?)⊆T>[1], frame: Frame[1]): Window[1]
-{
-   ^Window(
-      partitionBy = [col($cols.name)],
-      frame = $frame
-   );
-}
-
-function meta::pure::dsl::dataframe::partitionBy(columns: Expression[*]): Window[1]
-{
-   ^Window(partitionBy = $columns, orderBy = []);
-}
-
-function meta::pure::dsl::dataframe::orderBy(window: Window[1], clauses: OrderByClause[*]): Window[1]
-{
-   ^$window(orderBy = $clauses);
-}
-
-function meta::pure::dsl::dataframe::rowsUnboundedPreceding(window: Window[1]): Window[1]
-{
-   ^$window(
-      frameType = WindowFrameType.ROWS, 
-      frameStart = ^WindowFrameBound(type = WindowFrameBoundType.UNBOUNDED_PRECEDING),
-      frameEnd = ^WindowFrameBound(type = WindowFrameBoundType.CURRENT_ROW)
-   );
-}
 
 // Type-safe qualify function for window functions
 function meta::pure::dsl::dataframe::qualify<T>(df: DataFrame<T>[1], condition: Expression[1]): DataFrame<T>[1]
@@ -956,48 +805,7 @@ function meta::pure::dsl::dataframe::qualify<T>(df: DataFrame<T>[1], condition: 
    ^$df(qualify = $condition);
 }
 
-function meta::pure::dsl::dataframe::rowsBetween(window: Window[1], start: WindowFrameBound[1], end: WindowFrameBound[1]): Window[1]
-{
-   let frame = ^Rows(
-      offsetFrom = toFrameValue($start),
-      offsetTo = toFrameValue($end)
-   );
-   ^$window(frame = $frame);
-}
 
-function meta::pure::dsl::dataframe::rangeBetween(window: Window[1], start: WindowFrameBound[1], end: WindowFrameBound[1]): Window[1]
-{
-   let frame = ^Range(
-      offsetFrom = toFrameValue($start),
-      offsetTo = toFrameValue($end)
-   );
-   ^$window(frame = $frame);
-}
-
-function meta::pure::dsl::dataframe::unboundedPreceding(): WindowFrameBound[1]
-{
-   ^WindowFrameBound(type = WindowFrameBoundType.UNBOUNDED_PRECEDING);
-}
-
-function meta::pure::dsl::dataframe::unboundedFollowing(): WindowFrameBound[1]
-{
-   ^WindowFrameBound(type = WindowFrameBoundType.UNBOUNDED_FOLLOWING);
-}
-
-function meta::pure::dsl::dataframe::currentRow(): WindowFrameBound[1]
-{
-   ^WindowFrameBound(type = WindowFrameBoundType.CURRENT_ROW);
-}
-
-function meta::pure::dsl::dataframe::preceding(offset: Integer[1]): WindowFrameBound[1]
-{
-   ^WindowFrameBound(type = WindowFrameBoundType.PRECEDING, offset = $offset);
-}
-
-function meta::pure::dsl::dataframe::following(offset: Integer[1]): WindowFrameBound[1]
-{
-   ^WindowFrameBound(type = WindowFrameBoundType.FOLLOWING, offset = $offset);
-}
 
 // Helper function to convert WindowFrameBound to FrameValue
 function meta::pure::dsl::dataframe::toFrameValue(bound: WindowFrameBound[1]): FrameValue[1]

--- a/src/main/resources/pure/dsl/dataframe/orderby.pure
+++ b/src/main/resources/pure/dsl/dataframe/orderby.pure
@@ -1,0 +1,28 @@
+// Copyright 2025 Neema Raphael
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::dsl::dataframe::*;
+import meta::pure::dsl::dataframe::metamodel::*;
+import meta::pure::dsl::dataframe::metamodel::window::*;
+
+// OrderBy helper functions
+function meta::pure::dsl::dataframe::asc<T>(col: ColSpec<(?:?)⊆T>[1]): OrderByClause[1]
+{
+   ^OrderByClause(expression = col($col.name), direction = SortDirection.ASC);
+}
+
+function meta::pure::dsl::dataframe::desc<T>(col: ColSpec<(?:?)⊆T>[1]): OrderByClause[1]
+{
+   ^OrderByClause(expression = col($col.name), direction = SortDirection.DESC);
+}

--- a/src/main/resources/pure/dsl/dataframe/over.pure
+++ b/src/main/resources/pure/dsl/dataframe/over.pure
@@ -1,0 +1,208 @@
+// Copyright 2025 Neema Raphael
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::dsl::dataframe::*;
+import meta::pure::dsl::dataframe::metamodel::*;
+import meta::pure::dsl::dataframe::metamodel::window::*;
+import meta::pure::dsl::dataframe::metamodel::frame::*;
+
+// Original over function for backward compatibility
+function meta::pure::dsl::dataframe::over(expr: Expression[1], window: Window[1]): WindowFunction[1]
+{
+   let functionName = $expr->getFunctionName();
+   
+   if($functionName == 'row_number')
+   {
+      ^RowNumberFunction(functionName = $functionName, parameters = [], window = $window);
+   }
+   else if($functionName == 'rank')
+   {
+      ^RankFunction(functionName = $functionName, parameters = [], window = $window);
+   }
+   else if($functionName == 'dense_rank')
+   {
+      ^DenseRankFunction(functionName = $functionName, parameters = [], window = $window);
+   }
+   else if($functionName == 'lead' || $functionName == 'lag')
+   {
+      let params = $expr->getFunctionParameters();
+      let valueExpr = $params->at(0);
+      let offset = if($params->size() >= 2, |$params->at(1), |^LiteralExpression(value = 1));
+      let defaultValue = if($params->size() >= 3, |$params->at(2), |^LiteralExpression(value = null));
+      
+      ^LeadLagFunction(functionName = $functionName, parameters = [$valueExpr], window = $window, offset = $offset, defaultValue = $defaultValue);
+   }
+   else if($functionName == 'first_value' || $functionName == 'last_value')
+   {
+      let params = $expr->getFunctionParameters();
+      let valueExpr = $params->at(0);
+      
+      ^FirstLastValueFunction(functionName = $functionName, parameters = [$valueExpr], window = $window);
+   }
+   else
+   {
+      // Default to aggregate window function for sum, avg, min, max, count, etc.
+      let params = if($expr->instanceOf(FunctionExpression), 
+                     |$expr->cast(@FunctionExpression).parameters, 
+                     |[$expr]);
+      
+      ^AggregateWindowFunction(functionName = $functionName, parameters = $params, window = $window);
+   }
+}
+
+// Window function creation helper
+function meta::pure::dsl::dataframe::over(expr: Expression[1], window: Window[1]): WindowFunction[1]
+{
+   ^WindowFunction(
+      function = $expr,
+      window = $window
+   );
+}
+
+// Type-safe over functions for window operations
+
+function 
+   <<functionType.NormalizeRequiredFunction,
+   PCT.function>>
+   meta::pure::dsl::dataframe::over<T>(cols: ColSpec<(?:?)⊆T>[1]): Window[1]
+{
+   ^Window(
+      partitionBy = [col($cols.name)]
+   );
+}
+
+function 
+   <<functionType.NormalizeRequiredFunction,
+   PCT.function>>
+   meta::pure::dsl::dataframe::over<T>(cols: ColSpecArray<(?:?)⊆T>[1]): Window[1]
+{
+   ^Window(
+      partitionBy = $cols.names->map(c | col($c))
+   );
+}
+
+function 
+   <<functionType.NormalizeRequiredFunction,
+   PCT.function>>
+   meta::pure::dsl::dataframe::over<T>(orderBy: OrderByClause[*]): Window[1]
+{
+   ^Window(
+      orderBy = $orderBy
+   );
+}
+
+function 
+   <<functionType.NormalizeRequiredFunction,
+   PCT.function>>
+   meta::pure::dsl::dataframe::over<T>(frame: Frame[1]): Window[1]
+{
+   ^Window(
+      frame = $frame
+   );
+}
+
+function 
+   <<functionType.NormalizeRequiredFunction,
+   PCT.function>>
+   meta::pure::dsl::dataframe::over<T>(cols: ColSpec<(?:?)⊆T>[1], orderBy: OrderByClause[*]): Window[1]
+{
+   ^Window(
+      partitionBy = [col($cols.name)],
+      orderBy = $orderBy
+   );
+}
+
+function 
+   <<functionType.NormalizeRequiredFunction,
+   PCT.function>>
+   meta::pure::dsl::dataframe::over<T>(cols: ColSpecArray<(?:?)⊆T>[1], orderBy: OrderByClause[*]): Window[1]
+{
+   ^Window(
+      partitionBy = $cols.names->map(c | col($c)),
+      orderBy = $orderBy
+   );
+}
+
+function 
+   <<functionType.NormalizeRequiredFunction,
+   PCT.function>>
+   meta::pure::dsl::dataframe::over<T>(cols: ColSpec<(?:?)⊆T>[1], frame: Frame[1]): Window[1]
+{
+   ^Window(
+      partitionBy = [col($cols.name)],
+      frame = $frame
+   );
+}
+
+function meta::pure::dsl::dataframe::partitionBy(columns: Expression[*]): Window[1]
+{
+   ^Window(partitionBy = $columns, orderBy = []);
+}
+
+function meta::pure::dsl::dataframe::orderBy(window: Window[1], clauses: OrderByClause[*]): Window[1]
+{
+   ^$window(orderBy = $clauses);
+}
+
+function meta::pure::dsl::dataframe::rowsUnboundedPreceding(window: Window[1]): Window[1]
+{
+   ^$window(
+      frameType = WindowFrameType.ROWS, 
+      frameStart = ^WindowFrameBound(type = WindowFrameBoundType.UNBOUNDED_PRECEDING),
+      frameEnd = ^WindowFrameBound(type = WindowFrameBoundType.CURRENT_ROW)
+   );
+}
+
+function meta::pure::dsl::dataframe::rowsBetween(window: Window[1], start: WindowFrameBound[1], end: WindowFrameBound[1]): Window[1]
+{
+   let frame = ^Rows(
+      offsetFrom = toFrameValue($start),
+      offsetTo = toFrameValue($end)
+   );
+   ^$window(frame = $frame);
+}
+
+function meta::pure::dsl::dataframe::rangeBetween(window: Window[1], start: WindowFrameBound[1], end: WindowFrameBound[1]): Window[1]
+{
+   let frame = ^Range(
+      offsetFrom = toFrameValue($start),
+      offsetTo = toFrameValue($end)
+   );
+   ^$window(frame = $frame);
+}
+
+function meta::pure::dsl::dataframe::unboundedPreceding(): WindowFrameBound[1]
+{
+   ^WindowFrameBound(type = WindowFrameBoundType.UNBOUNDED_PRECEDING);
+}
+
+function meta::pure::dsl::dataframe::unboundedFollowing(): WindowFrameBound[1]
+{
+   ^WindowFrameBound(type = WindowFrameBoundType.UNBOUNDED_FOLLOWING);
+}
+
+function meta::pure::dsl::dataframe::currentRow(): WindowFrameBound[1]
+{
+   ^WindowFrameBound(type = WindowFrameBoundType.CURRENT_ROW);
+}
+
+function meta::pure::dsl::dataframe::preceding(offset: Integer[1]): WindowFrameBound[1]
+{
+   ^WindowFrameBound(type = WindowFrameBoundType.PRECEDING, offset = $offset);
+}
+
+function meta::pure::dsl::dataframe::following(offset: Integer[1]): WindowFrameBound[1]
+{
+   ^WindowFrameBound(type = WindowFrameBoundType.FOLLOWING, offset = $offset);
+}


### PR DESCRIPTION
Move all "over" functions from dataframe.pure to over.pure and orderBy functions to orderby.pure to break up the dataframe.pure file into more manageable pieces.

Requested by: Neema.Raphael@gs.com
Link to Devin run: https://app.devin.ai/sessions/519b629242134e22918d4333208fc699