### PR TITLE
Add more scalar functions

### DIFF
--- a/src/main/resources/pure/dsl/dataframe/scalar/conditionalFunctions.pure
+++ b/src/main/resources/pure/dsl/dataframe/scalar/conditionalFunctions.pure
@@ -1,0 +1,117 @@
+// Copyright 2025 Neema Raphael
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::dsl::dataframe::*;
+import meta::pure::dsl::dataframe::metamodel::*;
+import meta::pure::dsl::dataframe::metamodel::scalar::*;
+import meta::pure::dsl::dataframe::scalar::*;
+
+/**
+ * Implementation of conditional scalar functions for DataFrame DSL
+ */
+
+// Initialize conditional functions in the scalar function registry
+function meta::pure::dsl::dataframe::scalar::initializeConditionalFunctions(registry: Map<String, ScalarFunctionImplementation>[1]): Map<String, ScalarFunctionImplementation>[1]
+{
+   // COALESCE function
+   $registry->put('coalesce', ^ScalarFunctionImplementation(
+      standardName = 'COALESCE',
+      databases = newMap([
+         pair(Database.SNOWFLAKE, 'COALESCE'),
+         pair(Database.DUCKDB, 'COALESCE'),
+         pair(Database.BIGQUERY, 'COALESCE'),
+         pair(Database.DATABRICKS, 'COALESCE'),
+         pair(Database.REDSHIFT, 'COALESCE'),
+         pair(Database.POSTGRES, 'COALESCE')
+      ])
+   ));
+   
+   // NULLIF function
+   $registry->put('nullif', ^ScalarFunctionImplementation(
+      standardName = 'NULLIF',
+      databases = newMap([
+         pair(Database.SNOWFLAKE, 'NULLIF'),
+         pair(Database.DUCKDB, 'NULLIF'),
+         pair(Database.BIGQUERY, 'NULLIF'),
+         pair(Database.DATABRICKS, 'NULLIF'),
+         pair(Database.REDSHIFT, 'NULLIF'),
+         pair(Database.POSTGRES, 'NULLIF')
+      ])
+   ));
+   
+   // GREATEST function
+   $registry->put('greatest', ^ScalarFunctionImplementation(
+      standardName = 'GREATEST',
+      databases = newMap([
+         pair(Database.SNOWFLAKE, 'GREATEST'),
+         pair(Database.DUCKDB, 'GREATEST'),
+         pair(Database.BIGQUERY, 'GREATEST'),
+         pair(Database.DATABRICKS, 'GREATEST'),
+         pair(Database.REDSHIFT, 'GREATEST'),
+         pair(Database.POSTGRES, 'GREATEST')
+      ])
+   ));
+   
+   // LEAST function
+   $registry->put('least', ^ScalarFunctionImplementation(
+      standardName = 'LEAST',
+      databases = newMap([
+         pair(Database.SNOWFLAKE, 'LEAST'),
+         pair(Database.DUCKDB, 'LEAST'),
+         pair(Database.BIGQUERY, 'LEAST'),
+         pair(Database.DATABRICKS, 'LEAST'),
+         pair(Database.REDSHIFT, 'LEAST'),
+         pair(Database.POSTGRES, 'LEAST')
+      ])
+   ));
+   
+   $registry;
+}
+
+// Factory functions for creating conditional scalar functions
+function meta::pure::dsl::dataframe::coalesce(expr1: Expression[1], expr2: Expression[1], additional: Expression[*]): ScalarFunction[1]
+{
+   ^CommonScalarFunction(
+      functionName = 'coalesce',
+      parameters = $expr1->concatenate($expr2)->concatenate($additional)->toOneMany(),
+      implementation = scalarFunctionRegistry()->get('coalesce')->toOne()
+   );
+}
+
+function meta::pure::dsl::dataframe::nullif(expr: Expression[1], compareExpr: Expression[1]): ScalarFunction[1]
+{
+   ^CommonScalarFunction(
+      functionName = 'nullif',
+      parameters = [$expr, $compareExpr],
+      implementation = scalarFunctionRegistry()->get('nullif')->toOne()
+   );
+}
+
+function meta::pure::dsl::dataframe::greatest(expr1: Expression[1], expr2: Expression[1], additional: Expression[*]): ScalarFunction[1]
+{
+   ^CommonScalarFunction(
+      functionName = 'greatest',
+      parameters = $expr1->concatenate($expr2)->concatenate($additional)->toOneMany(),
+      implementation = scalarFunctionRegistry()->get('greatest')->toOne()
+   );
+}
+
+function meta::pure::dsl::dataframe::least(expr1: Expression[1], expr2: Expression[1], additional: Expression[*]): ScalarFunction[1]
+{
+   ^CommonScalarFunction(
+      functionName = 'least',
+      parameters = $expr1->concatenate($expr2)->concatenate($additional)->toOneMany(),
+      implementation = scalarFunctionRegistry()->get('least')->toOne()
+   );
+}

--- a/src/main/resources/pure/dsl/dataframe/scalar/conversionFunctions.pure
+++ b/src/main/resources/pure/dsl/dataframe/scalar/conversionFunctions.pure
@@ -1,0 +1,237 @@
+// Copyright 2025 Neema Raphael
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::dsl::dataframe::*;
+import meta::pure::dsl::dataframe::metamodel::*;
+import meta::pure::dsl::dataframe::metamodel::scalar::*;
+import meta::pure::dsl::dataframe::scalar::*;
+
+/**
+ * Implementation of type conversion scalar functions for DataFrame DSL
+ */
+
+// Initialize type conversion functions in the scalar function registry
+function meta::pure::dsl::dataframe::scalar::initializeConversionFunctions(registry: Map<String, ScalarFunctionImplementation>[1]): Map<String, ScalarFunctionImplementation>[1]
+{
+   // CAST function
+   $registry->put('cast', ^ScalarFunctionImplementation(
+      standardName = 'CAST',
+      databases = newMap([
+         pair(Database.SNOWFLAKE, 'CAST'),
+         pair(Database.DUCKDB, 'CAST'),
+         pair(Database.BIGQUERY, 'CAST'),
+         pair(Database.DATABRICKS, 'CAST'),
+         pair(Database.REDSHIFT, 'CAST'),
+         pair(Database.POSTGRES, 'CAST')
+      ]),
+      // Special handling for CAST syntax which varies slightly by database
+      parameterTransformations = newMap([
+         pair(Database.SNOWFLAKE, {params: Expression[*] | 
+            if($params->size() >= 2,
+               [^FunctionExpression(
+                  functionName = 'CAST',
+                  parameters = [$params->at(0)->concatenate(
+                     ^LiteralExpression(value = ' AS ' + $params->at(1)->cast(@LiteralExpression).value->toString())
+                  )]
+               )],
+               $params
+            )
+         }),
+         pair(Database.DUCKDB, {params: Expression[*] | 
+            if($params->size() >= 2,
+               [^FunctionExpression(
+                  functionName = 'CAST',
+                  parameters = [$params->at(0)->concatenate(
+                     ^LiteralExpression(value = ' AS ' + $params->at(1)->cast(@LiteralExpression).value->toString())
+                  )]
+               )],
+               $params
+            )
+         }),
+         pair(Database.BIGQUERY, {params: Expression[*] | 
+            if($params->size() >= 2,
+               [^FunctionExpression(
+                  functionName = 'CAST',
+                  parameters = [$params->at(0)->concatenate(
+                     ^LiteralExpression(value = ' AS ' + $params->at(1)->cast(@LiteralExpression).value->toString())
+                  )]
+               )],
+               $params
+            )
+         }),
+         pair(Database.DATABRICKS, {params: Expression[*] | 
+            if($params->size() >= 2,
+               [^FunctionExpression(
+                  functionName = 'CAST',
+                  parameters = [$params->at(0)->concatenate(
+                     ^LiteralExpression(value = ' AS ' + $params->at(1)->cast(@LiteralExpression).value->toString())
+                  )]
+               )],
+               $params
+            )
+         }),
+         pair(Database.REDSHIFT, {params: Expression[*] | 
+            if($params->size() >= 2,
+               [^FunctionExpression(
+                  functionName = 'CAST',
+                  parameters = [$params->at(0)->concatenate(
+                     ^LiteralExpression(value = ' AS ' + $params->at(1)->cast(@LiteralExpression).value->toString())
+                  )]
+               )],
+               $params
+            )
+         }),
+         pair(Database.POSTGRES, {params: Expression[*] | 
+            if($params->size() >= 2,
+               [^FunctionExpression(
+                  functionName = 'CAST',
+                  parameters = [$params->at(0)->concatenate(
+                     ^LiteralExpression(value = ' AS ' + $params->at(1)->cast(@LiteralExpression).value->toString())
+                  )]
+               )],
+               $params
+            )
+         })
+      ])
+   ));
+   
+   // TO_NUMBER function
+   $registry->put('to_number', ^ScalarFunctionImplementation(
+      standardName = 'TO_NUMBER',
+      databases = newMap([
+         pair(Database.SNOWFLAKE, 'TO_NUMBER'),
+         pair(Database.DUCKDB, 'CAST'),
+         pair(Database.BIGQUERY, 'CAST'),
+         pair(Database.DATABRICKS, 'CAST'),
+         pair(Database.REDSHIFT, 'TO_NUMBER'),
+         pair(Database.POSTGRES, 'TO_NUMBER')
+      ]),
+      parameterTransformations = newMap([
+         pair(Database.DUCKDB, {params: Expression[*] | 
+            if($params->size() >= 1,
+               [^FunctionExpression(
+                  functionName = 'CAST',
+                  parameters = [$params->at(0)->concatenate(
+                     ^LiteralExpression(value = ' AS DOUBLE')
+                  )]
+               )],
+               $params
+            )
+         }),
+         pair(Database.BIGQUERY, {params: Expression[*] | 
+            if($params->size() >= 1,
+               [^FunctionExpression(
+                  functionName = 'CAST',
+                  parameters = [$params->at(0)->concatenate(
+                     ^LiteralExpression(value = ' AS NUMERIC')
+                  )]
+               )],
+               $params
+            )
+         }),
+         pair(Database.DATABRICKS, {params: Expression[*] | 
+            if($params->size() >= 1,
+               [^FunctionExpression(
+                  functionName = 'CAST',
+                  parameters = [$params->at(0)->concatenate(
+                     ^LiteralExpression(value = ' AS DECIMAL(38, 10)')
+                  )]
+               )],
+               $params
+            )
+         })
+      ])
+   ));
+   
+   // TO_DATE function
+   $registry->put('to_date', ^ScalarFunctionImplementation(
+      standardName = 'TO_DATE',
+      databases = newMap([
+         pair(Database.SNOWFLAKE, 'TO_DATE'),
+         pair(Database.DUCKDB, 'TO_DATE'),
+         pair(Database.BIGQUERY, 'PARSE_DATE'),
+         pair(Database.DATABRICKS, 'TO_DATE'),
+         pair(Database.REDSHIFT, 'TO_DATE'),
+         pair(Database.POSTGRES, 'TO_DATE')
+      ]),
+      parameterTransformations = newMap([
+         pair(Database.BIGQUERY, {params: Expression[*] | 
+            if($params->size() >= 2,
+               [$params->at(1), $params->at(0)],  // BigQuery has reversed parameter order
+               $params
+            )
+         })
+      ])
+   ));
+   
+   // TO_TIMESTAMP function
+   $registry->put('to_timestamp', ^ScalarFunctionImplementation(
+      standardName = 'TO_TIMESTAMP',
+      databases = newMap([
+         pair(Database.SNOWFLAKE, 'TO_TIMESTAMP'),
+         pair(Database.DUCKDB, 'TO_TIMESTAMP'),
+         pair(Database.BIGQUERY, 'PARSE_TIMESTAMP'),
+         pair(Database.DATABRICKS, 'TO_TIMESTAMP'),
+         pair(Database.REDSHIFT, 'TO_TIMESTAMP'),
+         pair(Database.POSTGRES, 'TO_TIMESTAMP')
+      ]),
+      parameterTransformations = newMap([
+         pair(Database.BIGQUERY, {params: Expression[*] | 
+            if($params->size() >= 2,
+               [$params->at(1), $params->at(0)],  // BigQuery has reversed parameter order
+               $params
+            )
+         })
+      ])
+   ));
+   
+   $registry;
+}
+
+// Factory functions for creating type conversion scalar functions
+function meta::pure::dsl::dataframe::cast(expr: Expression[1], type: Expression[1]): ScalarFunction[1]
+{
+   ^CommonScalarFunction(
+      functionName = 'cast',
+      parameters = [$expr, $type],
+      implementation = scalarFunctionRegistry()->get('cast')->toOne()
+   );
+}
+
+function meta::pure::dsl::dataframe::toNumber(expr: Expression[1]): ScalarFunction[1]
+{
+   ^CommonScalarFunction(
+      functionName = 'to_number',
+      parameters = [$expr],
+      implementation = scalarFunctionRegistry()->get('to_number')->toOne()
+   );
+}
+
+function meta::pure::dsl::dataframe::toDate(expr: Expression[1], format: Expression[1]): ScalarFunction[1]
+{
+   ^CommonScalarFunction(
+      functionName = 'to_date',
+      parameters = [$expr, $format],
+      implementation = scalarFunctionRegistry()->get('to_date')->toOne()
+   );
+}
+
+function meta::pure::dsl::dataframe::toTimestamp(expr: Expression[1], format: Expression[1]): ScalarFunction[1]
+{
+   ^CommonScalarFunction(
+      functionName = 'to_timestamp',
+      parameters = [$expr, $format],
+      implementation = scalarFunctionRegistry()->get('to_timestamp')->toOne()
+   );
+}

--- a/src/main/resources/pure/dsl/dataframe/scalar/dateFunctions.pure
+++ b/src/main/resources/pure/dsl/dataframe/scalar/dateFunctions.pure
@@ -108,6 +108,154 @@ function meta::pure::dsl::dataframe::scalar::initializeDateFunctions(registry: M
       ])
    ));
    
+   // CURRENT_DATE function
+   $registry->put('current_date', ^ScalarFunctionImplementation(
+      standardName = 'CURRENT_DATE',
+      databases = newMap([
+         pair(Database.SNOWFLAKE, 'CURRENT_DATE'),
+         pair(Database.DUCKDB, 'CURRENT_DATE'),
+         pair(Database.BIGQUERY, 'CURRENT_DATE'),
+         pair(Database.DATABRICKS, 'CURRENT_DATE'),
+         pair(Database.REDSHIFT, 'CURRENT_DATE'),
+         pair(Database.POSTGRES, 'CURRENT_DATE')
+      ])
+   ));
+   
+   // DATE_ADD function with varying syntax
+   $registry->put('date_add', ^ScalarFunctionImplementation(
+      standardName = 'DATE_ADD',
+      databases = newMap([
+         pair(Database.SNOWFLAKE, 'DATEADD'),
+         pair(Database.DUCKDB, 'DATEADD'),
+         pair(Database.BIGQUERY, 'DATE_ADD'),
+         pair(Database.DATABRICKS, 'DATE_ADD'),
+         pair(Database.REDSHIFT, 'DATEADD'),
+         pair(Database.POSTGRES, 'CAST')
+      ]),
+      parameterTransformations = newMap([
+         // For Snowflake, Redshift and DuckDB, the order is (part, amount, date)
+         pair(Database.SNOWFLAKE, {params: Expression[*] | 
+            if($params->size() >= 3,
+               [$params->at(0), $params->at(2), $params->at(1)],
+               $params
+            )
+         }),
+         pair(Database.DUCKDB, {params: Expression[*] | 
+            if($params->size() >= 3,
+               [$params->at(0), $params->at(2), $params->at(1)],
+               $params
+            )
+         }),
+         pair(Database.REDSHIFT, {params: Expression[*] | 
+            if($params->size() >= 3,
+               [$params->at(0), $params->at(2), $params->at(1)],
+               $params
+            )
+         }),
+         // For Postgres, use interval
+         pair(Database.POSTGRES, {params: Expression[*] | 
+            if($params->size() >= 3,
+               [
+                  ^BinaryOperation(
+                     left = $params->at(1),
+                     operator = BinaryOperator.ADD,
+                     right = ^FunctionExpression(
+                        functionName = 'CAST',
+                        parameters = [
+                           ^BinaryOperation(
+                              left = $params->at(2),
+                              operator = BinaryOperator.CONCATENATE,
+                              right = ^LiteralExpression(value = ' ' + $params->at(0)->cast(@LiteralExpression).value->toString())
+                           ),
+                           ^LiteralExpression(value = 'AS INTERVAL')
+                        ]
+                     )
+                  )
+               ],
+               $params
+            )
+         })
+      ])
+   ));
+   
+   // DATE_SUB function with varying syntax
+   $registry->put('date_sub', ^ScalarFunctionImplementation(
+      standardName = 'DATE_SUB',
+      databases = newMap([
+         pair(Database.SNOWFLAKE, 'DATEADD'),
+         pair(Database.DUCKDB, 'DATEADD'),
+         pair(Database.BIGQUERY, 'DATE_SUB'),
+         pair(Database.DATABRICKS, 'DATE_SUB'),
+         pair(Database.REDSHIFT, 'DATEADD'),
+         pair(Database.POSTGRES, 'CAST')
+      ]),
+      parameterTransformations = newMap([
+         // For Snowflake, Redshift and DuckDB, negate the amount
+         pair(Database.SNOWFLAKE, {params: Expression[*] | 
+            if($params->size() >= 3,
+               [
+                  $params->at(0),
+                  $params->at(1),
+                  ^UnaryOperation(
+                     operator = UnaryOperator.MINUS,
+                     expression = $params->at(2)
+                  )
+               ],
+               $params
+            )
+         }),
+         pair(Database.DUCKDB, {params: Expression[*] | 
+            if($params->size() >= 3,
+               [
+                  $params->at(0),
+                  $params->at(1),
+                  ^UnaryOperation(
+                     operator = UnaryOperator.MINUS,
+                     expression = $params->at(2)
+                  )
+               ],
+               $params
+            )
+         }),
+         pair(Database.REDSHIFT, {params: Expression[*] | 
+            if($params->size() >= 3,
+               [
+                  $params->at(0),
+                  $params->at(1),
+                  ^UnaryOperation(
+                     operator = UnaryOperator.MINUS,
+                     expression = $params->at(2)
+                  )
+               ],
+               $params
+            )
+         }),
+         // For Postgres, use interval with negation
+         pair(Database.POSTGRES, {params: Expression[*] | 
+            if($params->size() >= 3,
+               [
+                  ^BinaryOperation(
+                     left = $params->at(1),
+                     operator = BinaryOperator.SUBTRACT,
+                     right = ^FunctionExpression(
+                        functionName = 'CAST',
+                        parameters = [
+                           ^BinaryOperation(
+                              left = $params->at(2),
+                              operator = BinaryOperator.CONCATENATE,
+                              right = ^LiteralExpression(value = ' ' + $params->at(0)->cast(@LiteralExpression).value->toString())
+                           ),
+                           ^LiteralExpression(value = 'AS INTERVAL')
+                        ]
+                     )
+                  )
+               ],
+               $params
+            )
+         })
+      ])
+   ));
+   
    $registry;
 }
 
@@ -145,5 +293,32 @@ function meta::pure::dsl::dataframe::time_bucket(interval: Expression[1], timest
       functionName = 'time_bucket',
       parameters = [$interval, $timestamp],
       implementation = scalarFunctionRegistry()->get('time_bucket')->toOne()
+   );
+}
+
+function meta::pure::dsl::dataframe::currentDate(): ScalarFunction[1]
+{
+   ^CommonScalarFunction(
+      functionName = 'current_date',
+      parameters = [],
+      implementation = scalarFunctionRegistry()->get('current_date')->toOne()
+   );
+}
+
+function meta::pure::dsl::dataframe::dateAdd(datepart: Expression[1], date: Expression[1], amount: Expression[1]): ScalarFunction[1]
+{
+   ^CommonScalarFunction(
+      functionName = 'date_add',
+      parameters = [$datepart, $date, $amount],
+      implementation = scalarFunctionRegistry()->get('date_add')->toOne()
+   );
+}
+
+function meta::pure::dsl::dataframe::dateSub(datepart: Expression[1], date: Expression[1], amount: Expression[1]): ScalarFunction[1]
+{
+   ^CommonScalarFunction(
+      functionName = 'date_sub',
+      parameters = [$datepart, $date, $amount],
+      implementation = scalarFunctionRegistry()->get('date_sub')->toOne()
    );
 }

--- a/src/main/resources/pure/dsl/dataframe/scalar/mathFunctions.pure
+++ b/src/main/resources/pure/dsl/dataframe/scalar/mathFunctions.pure
@@ -102,6 +102,84 @@ function meta::pure::dsl::dataframe::scalar::initializeMathFunctions(registry: M
       ])
    ));
    
+   // ROUND function
+   $registry->put('round', ^ScalarFunctionImplementation(
+      standardName = 'ROUND',
+      databases = newMap([
+         pair(Database.SNOWFLAKE, 'ROUND'),
+         pair(Database.DUCKDB, 'ROUND'),
+         pair(Database.BIGQUERY, 'ROUND'),
+         pair(Database.DATABRICKS, 'ROUND'),
+         pair(Database.REDSHIFT, 'ROUND'),
+         pair(Database.POSTGRES, 'ROUND')
+      ])
+   ));
+   
+   // CEILING function
+   $registry->put('ceiling', ^ScalarFunctionImplementation(
+      standardName = 'CEILING',
+      databases = newMap([
+         pair(Database.SNOWFLAKE, 'CEILING'),
+         pair(Database.DUCKDB, 'CEILING'),
+         pair(Database.BIGQUERY, 'CEIL'),
+         pair(Database.DATABRICKS, 'CEILING'),
+         pair(Database.REDSHIFT, 'CEILING'),
+         pair(Database.POSTGRES, 'CEILING')
+      ])
+   ));
+   
+   // FLOOR function
+   $registry->put('floor', ^ScalarFunctionImplementation(
+      standardName = 'FLOOR',
+      databases = newMap([
+         pair(Database.SNOWFLAKE, 'FLOOR'),
+         pair(Database.DUCKDB, 'FLOOR'),
+         pair(Database.BIGQUERY, 'FLOOR'),
+         pair(Database.DATABRICKS, 'FLOOR'),
+         pair(Database.REDSHIFT, 'FLOOR'),
+         pair(Database.POSTGRES, 'FLOOR')
+      ])
+   ));
+   
+   // LOG function (base 10)
+   $registry->put('log', ^ScalarFunctionImplementation(
+      standardName = 'LOG',
+      databases = newMap([
+         pair(Database.SNOWFLAKE, 'LOG'),
+         pair(Database.DUCKDB, 'LOG10'),
+         pair(Database.BIGQUERY, 'LOG10'),
+         pair(Database.DATABRICKS, 'LOG10'),
+         pair(Database.REDSHIFT, 'LOG10'),
+         pair(Database.POSTGRES, 'LOG10')
+      ])
+   ));
+   
+   // LN function (natural log)
+   $registry->put('ln', ^ScalarFunctionImplementation(
+      standardName = 'LN',
+      databases = newMap([
+         pair(Database.SNOWFLAKE, 'LN'),
+         pair(Database.DUCKDB, 'LN'),
+         pair(Database.BIGQUERY, 'LN'),
+         pair(Database.DATABRICKS, 'LN'),
+         pair(Database.REDSHIFT, 'LN'),
+         pair(Database.POSTGRES, 'LN')
+      ])
+   ));
+   
+   // MOD function
+   $registry->put('mod', ^ScalarFunctionImplementation(
+      standardName = 'MOD',
+      databases = newMap([
+         pair(Database.SNOWFLAKE, 'MOD'),
+         pair(Database.DUCKDB, 'MOD'),
+         pair(Database.BIGQUERY, 'MOD'),
+         pair(Database.DATABRICKS, 'MOD'),
+         pair(Database.REDSHIFT, 'MOD'),
+         pair(Database.POSTGRES, 'MOD')
+      ])
+   ));
+   
    $registry;
 }
 
@@ -157,5 +235,59 @@ function meta::pure::dsl::dataframe::power(base: Expression[1], exponent: Expres
       functionName = 'power',
       parameters = [$base, $exponent],
       implementation = scalarFunctionRegistry()->get('power')->toOne()
+   );
+}
+
+function meta::pure::dsl::dataframe::round(expr: Expression[1], precision: Expression[1]): ScalarFunction[1]
+{
+   ^CommonScalarFunction(
+      functionName = 'round',
+      parameters = [$expr, $precision],
+      implementation = scalarFunctionRegistry()->get('round')->toOne()
+   );
+}
+
+function meta::pure::dsl::dataframe::ceiling(expr: Expression[1]): ScalarFunction[1]
+{
+   ^CommonScalarFunction(
+      functionName = 'ceiling',
+      parameters = [$expr],
+      implementation = scalarFunctionRegistry()->get('ceiling')->toOne()
+   );
+}
+
+function meta::pure::dsl::dataframe::floor(expr: Expression[1]): ScalarFunction[1]
+{
+   ^CommonScalarFunction(
+      functionName = 'floor',
+      parameters = [$expr],
+      implementation = scalarFunctionRegistry()->get('floor')->toOne()
+   );
+}
+
+function meta::pure::dsl::dataframe::log(expr: Expression[1]): ScalarFunction[1]
+{
+   ^CommonScalarFunction(
+      functionName = 'log',
+      parameters = [$expr],
+      implementation = scalarFunctionRegistry()->get('log')->toOne()
+   );
+}
+
+function meta::pure::dsl::dataframe::ln(expr: Expression[1]): ScalarFunction[1]
+{
+   ^CommonScalarFunction(
+      functionName = 'ln',
+      parameters = [$expr],
+      implementation = scalarFunctionRegistry()->get('ln')->toOne()
+   );
+}
+
+function meta::pure::dsl::dataframe::mod(dividend: Expression[1], divisor: Expression[1]): ScalarFunction[1]
+{
+   ^CommonScalarFunction(
+      functionName = 'mod',
+      parameters = [$dividend, $divisor],
+      implementation = scalarFunctionRegistry()->get('mod')->toOne()
    );
 }

--- a/src/main/resources/pure/dsl/dataframe/scalar/stringFunctions.pure
+++ b/src/main/resources/pure/dsl/dataframe/scalar/stringFunctions.pure
@@ -137,6 +137,99 @@ function meta::pure::dsl::dataframe::scalar::initializeStringFunctions(registry:
       ])
    ));
    
+   // LEFT function
+   $registry->put('left', ^ScalarFunctionImplementation(
+      standardName = 'LEFT',
+      databases = newMap([
+         pair(Database.SNOWFLAKE, 'LEFT'),
+         pair(Database.DUCKDB, 'LEFT'),
+         pair(Database.BIGQUERY, 'LEFT'),
+         pair(Database.DATABRICKS, 'LEFT'),
+         pair(Database.REDSHIFT, 'LEFT'),
+         pair(Database.POSTGRES, 'LEFT')
+      ])
+   ));
+   
+   // RIGHT function
+   $registry->put('right', ^ScalarFunctionImplementation(
+      standardName = 'RIGHT',
+      databases = newMap([
+         pair(Database.SNOWFLAKE, 'RIGHT'),
+         pair(Database.DUCKDB, 'RIGHT'),
+         pair(Database.BIGQUERY, 'RIGHT'),
+         pair(Database.DATABRICKS, 'RIGHT'),
+         pair(Database.REDSHIFT, 'RIGHT'),
+         pair(Database.POSTGRES, 'RIGHT')
+      ])
+   ));
+   
+   // SPLIT function with varying syntax
+   $registry->put('split', ^ScalarFunctionImplementation(
+      standardName = 'SPLIT',
+      databases = newMap([
+         pair(Database.SNOWFLAKE, 'SPLIT'),
+         pair(Database.DUCKDB, 'STRING_SPLIT'),
+         pair(Database.BIGQUERY, 'SPLIT'),
+         pair(Database.DATABRICKS, 'SPLIT'),
+         pair(Database.REDSHIFT, 'SPLIT_PART'),
+         pair(Database.POSTGRES, 'STRING_TO_ARRAY')
+      ]),
+      parameterTransformations = newMap([
+         // For Redshift, SPLIT_PART requires an index parameter
+         pair(Database.REDSHIFT, {params: Expression[*] | 
+            if($params->size() >= 2,
+               [$params->at(0), $params->at(1), ^LiteralExpression(value = '1')],
+               $params
+            )
+         }),
+         // For Postgres, STRING_TO_ARRAY has different parameter order
+         pair(Database.POSTGRES, {params: Expression[*] | 
+            if($params->size() >= 2,
+               [$params->at(0), $params->at(1)],
+               $params
+            )
+         })
+      ])
+   ));
+   
+   // REGEXP_EXTRACT function with varying syntax
+   $registry->put('regexp_extract', ^ScalarFunctionImplementation(
+      standardName = 'REGEXP_EXTRACT',
+      databases = newMap([
+         pair(Database.SNOWFLAKE, 'REGEXP_SUBSTR'),
+         pair(Database.DUCKDB, 'REGEXP_EXTRACT'),
+         pair(Database.BIGQUERY, 'REGEXP_EXTRACT'),
+         pair(Database.DATABRICKS, 'REGEXP_EXTRACT'),
+         pair(Database.REDSHIFT, 'REGEXP_SUBSTR'),
+         pair(Database.POSTGRES, 'REGEXP_MATCHES')
+      ]),
+      parameterTransformations = newMap([
+         // For Snowflake and Redshift, add position parameter
+         pair(Database.SNOWFLAKE, {params: Expression[*] | 
+            if($params->size() >= 2,
+               [$params->at(0), $params->at(1), ^LiteralExpression(value = '1'), ^LiteralExpression(value = '1')],
+               $params
+            )
+         }),
+         pair(Database.REDSHIFT, {params: Expression[*] | 
+            if($params->size() >= 2,
+               [$params->at(0), $params->at(1), ^LiteralExpression(value = '1'), ^LiteralExpression(value = '1')],
+               $params
+            )
+         }),
+         // For Postgres, wrap in array access
+         pair(Database.POSTGRES, {params: Expression[*] | 
+            if($params->size() >= 2,
+               [^FunctionExpression(
+                  functionName = 'REGEXP_MATCHES',
+                  parameters = [$params->at(0), $params->at(1)]
+               ), ^LiteralExpression(value = '[1]')],
+               $params
+            )
+         })
+      ])
+   ));
+   
    $registry;
 }
 
@@ -210,5 +303,41 @@ function meta::pure::dsl::dataframe::regexp_match(str: Expression[1], pattern: E
       functionName = 'regexp_match',
       parameters = [$str, $pattern],
       implementation = scalarFunctionRegistry()->get('regexp_match')->toOne()
+   );
+}
+
+function meta::pure::dsl::dataframe::left(str: Expression[1], length: Expression[1]): ScalarFunction[1]
+{
+   ^CommonScalarFunction(
+      functionName = 'left',
+      parameters = [$str, $length],
+      implementation = scalarFunctionRegistry()->get('left')->toOne()
+   );
+}
+
+function meta::pure::dsl::dataframe::right(str: Expression[1], length: Expression[1]): ScalarFunction[1]
+{
+   ^CommonScalarFunction(
+      functionName = 'right',
+      parameters = [$str, $length],
+      implementation = scalarFunctionRegistry()->get('right')->toOne()
+   );
+}
+
+function meta::pure::dsl::dataframe::split(str: Expression[1], delimiter: Expression[1]): ScalarFunction[1]
+{
+   ^CommonScalarFunction(
+      functionName = 'split',
+      parameters = [$str, $delimiter],
+      implementation = scalarFunctionRegistry()->get('split')->toOne()
+   );
+}
+
+function meta::pure::dsl::dataframe::regexpExtract(str: Expression[1], pattern: Expression[1]): ScalarFunction[1]
+{
+   ^CommonScalarFunction(
+      functionName = 'regexp_extract',
+      parameters = [$str, $pattern],
+      implementation = scalarFunctionRegistry()->get('regexp_extract')->toOne()
    );
 }

--- a/src/main/resources/pure/dsl/dataframe/scalarFunctions.pure
+++ b/src/main/resources/pure/dsl/dataframe/scalarFunctions.pure
@@ -28,72 +28,12 @@ function meta::pure::dsl::dataframe::initializeScalarFunctionRegistry(): Map<Str
 {
    let registry = newMap([]);
    
-   // Math functions
-   $registry->put('abs', ^ScalarFunctionImplementation(
-      standardName = 'ABS',
-      databases = newMap([
-         pair(Database.SNOWFLAKE, 'ABS'),
-         pair(Database.DUCKDB, 'ABS'),
-         pair(Database.BIGQUERY, 'ABS'),
-         pair(Database.DATABRICKS, 'ABS'),
-         pair(Database.REDSHIFT, 'ABS'),
-         pair(Database.POSTGRES, 'ABS')
-      ])
-   ));
-   
-   $registry->put('cos', ^ScalarFunctionImplementation(
-      standardName = 'COS',
-      databases = newMap([
-         pair(Database.SNOWFLAKE, 'COS'),
-         pair(Database.DUCKDB, 'COS'),
-         pair(Database.BIGQUERY, 'COS'),
-         pair(Database.DATABRICKS, 'COS'),
-         pair(Database.REDSHIFT, 'COS'),
-         pair(Database.POSTGRES, 'COS')
-      ])
-   ));
-   
-   // Date functions with identical syntax
-   $registry->put('date_part', ^ScalarFunctionImplementation(
-      standardName = 'DATE_PART',
-      databases = newMap([
-         pair(Database.SNOWFLAKE, 'DATE_PART'),
-         pair(Database.DUCKDB, 'DATE_PART'),
-         pair(Database.BIGQUERY, 'EXTRACT'),
-         pair(Database.DATABRICKS, 'DATE_PART'),
-         pair(Database.REDSHIFT, 'DATE_PART'),
-         pair(Database.POSTGRES, 'DATE_PART')
-      ])
-   ));
-   
-   // Date difference function with varying syntax
-   $registry->put('datediff', ^ScalarFunctionImplementation(
-      standardName = 'DATEDIFF',
-      databases = newMap([
-         pair(Database.SNOWFLAKE, 'DATEDIFF'),
-         pair(Database.DUCKDB, 'DATEDIFF'),
-         pair(Database.BIGQUERY, 'DATE_DIFF'),
-         pair(Database.DATABRICKS, 'DATEDIFF'),
-         pair(Database.REDSHIFT, 'DATEDIFF'),
-         pair(Database.POSTGRES, 'DATE_PART')
-      ]),
-      parameterTransformations = newMap([
-         // For Postgres, transform parameters to use DATE_PART with subtraction
-         pair(Database.POSTGRES, {params: Expression[*] | 
-            if($params->size() >= 3,
-               [
-                  ^LiteralExpression(value = 'day'),
-                  ^BinaryOperation(
-                     left = $params->at(2), 
-                     operator = BinaryOperator.SUBTRACT, 
-                     right = $params->at(1)
-                  )
-               ],
-               $params
-            )
-         })
-      ])
-   ));
+   // Initialize function categories
+   $registry = meta::pure::dsl::dataframe::scalar::initializeMathFunctions($registry);
+   $registry = meta::pure::dsl::dataframe::scalar::initializeDateFunctions($registry);
+   $registry = meta::pure::dsl::dataframe::scalar::initializeStringFunctions($registry);
+   $registry = meta::pure::dsl::dataframe::scalar::initializeConditionalFunctions($registry);
+   $registry = meta::pure::dsl::dataframe::scalar::initializeConversionFunctions($registry);
    
    $registry;
 }

--- a/src/test/resources/pure/dsl/tests/scalar_function_tests.pure
+++ b/src/test/resources/pure/dsl/tests/scalar_function_tests.pure
@@ -215,3 +215,321 @@ function <<test.Test>> meta::pure::dsl::tests::testDatabaseSpecificFunctions(): 
    
    true;
 }
+
+function <<test.Test>> meta::pure::dsl::tests::testConditionalFunctions(): Boolean[1]
+{
+   // Create a DataFrame with conditional functions
+   let df = select([
+      coalesce(col('value'), literal(0))->as('coalesced_value'),
+      nullif(col('value'), literal(0))->as('nullif_value'),
+      greatest(col('value1'), col('value2'), col('value3'))->as('greatest_value'),
+      least(col('value1'), col('value2'), col('value3'))->as('least_value')
+   ])
+   ->from(table('data'));
+   
+   // Test SQL generation across all supported databases
+   let snowflakeSQL = $df->generateSnowflakeSQL();
+   let duckdbSQL = $df->generateDuckDBSQL();
+   let bigquerySQL = $df->generateBigQuerySQL();
+   let databricksSQL = $df->generateDatabricksSQL();
+   let redshiftSQL = $df->generateRedshiftSQL();
+   let postgresSQL = $df->generatePostgresSQL();
+   
+   // Verify SQL contains expected syntax
+   assertEquals(true, $snowflakeSQL->contains('COALESCE(value, 0) AS coalesced_value'));
+   assertEquals(true, $snowflakeSQL->contains('NULLIF(value, 0) AS nullif_value'));
+   assertEquals(true, $snowflakeSQL->contains('GREATEST(value1, value2, value3) AS greatest_value'));
+   assertEquals(true, $snowflakeSQL->contains('LEAST(value1, value2, value3) AS least_value'));
+   
+   assertEquals(true, $duckdbSQL->contains('COALESCE(value, 0) AS coalesced_value'));
+   assertEquals(true, $duckdbSQL->contains('NULLIF(value, 0) AS nullif_value'));
+   assertEquals(true, $duckdbSQL->contains('GREATEST(value1, value2, value3) AS greatest_value'));
+   assertEquals(true, $duckdbSQL->contains('LEAST(value1, value2, value3) AS least_value'));
+   
+   assertEquals(true, $bigquerySQL->contains('COALESCE(value, 0) AS coalesced_value'));
+   assertEquals(true, $bigquerySQL->contains('NULLIF(value, 0) AS nullif_value'));
+   assertEquals(true, $bigquerySQL->contains('GREATEST(value1, value2, value3) AS greatest_value'));
+   assertEquals(true, $bigquerySQL->contains('LEAST(value1, value2, value3) AS least_value'));
+   
+   assertEquals(true, $databricksSQL->contains('COALESCE(value, 0) AS coalesced_value'));
+   assertEquals(true, $databricksSQL->contains('NULLIF(value, 0) AS nullif_value'));
+   assertEquals(true, $databricksSQL->contains('GREATEST(value1, value2, value3) AS greatest_value'));
+   assertEquals(true, $databricksSQL->contains('LEAST(value1, value2, value3) AS least_value'));
+   
+   assertEquals(true, $redshiftSQL->contains('COALESCE(value, 0) AS coalesced_value'));
+   assertEquals(true, $redshiftSQL->contains('NULLIF(value, 0) AS nullif_value'));
+   assertEquals(true, $redshiftSQL->contains('GREATEST(value1, value2, value3) AS greatest_value'));
+   assertEquals(true, $redshiftSQL->contains('LEAST(value1, value2, value3) AS least_value'));
+   
+   assertEquals(true, $postgresSQL->contains('COALESCE(value, 0) AS coalesced_value'));
+   assertEquals(true, $postgresSQL->contains('NULLIF(value, 0) AS nullif_value'));
+   assertEquals(true, $postgresSQL->contains('GREATEST(value1, value2, value3) AS greatest_value'));
+   assertEquals(true, $postgresSQL->contains('LEAST(value1, value2, value3) AS least_value'));
+   
+   true;
+}
+
+function <<test.Test>> meta::pure::dsl::tests::testConversionFunctions(): Boolean[1]
+{
+   // Create a DataFrame with conversion functions
+   let df = select([
+      cast(col('value'), literal('INTEGER'))->as('int_value'),
+      toNumber(col('string_value'))->as('numeric_value'),
+      toDate(col('date_string'), literal('YYYY-MM-DD'))->as('date_value'),
+      toTimestamp(col('timestamp_string'), literal('YYYY-MM-DD HH24:MI:SS'))->as('timestamp_value')
+   ])
+   ->from(table('data'));
+   
+   // Test SQL generation across all supported databases
+   let snowflakeSQL = $df->generateSnowflakeSQL();
+   let duckdbSQL = $df->generateDuckDBSQL();
+   let bigquerySQL = $df->generateBigQuerySQL();
+   let databricksSQL = $df->generateDatabricksSQL();
+   let redshiftSQL = $df->generateRedshiftSQL();
+   let postgresSQL = $df->generatePostgresSQL();
+   
+   // Verify SQL contains expected syntax
+   assertEquals(true, $snowflakeSQL->contains('CAST(value AS INTEGER) AS int_value'));
+   assertEquals(true, $snowflakeSQL->contains('TO_NUMBER(string_value) AS numeric_value'));
+   assertEquals(true, $snowflakeSQL->contains('TO_DATE(date_string, \'YYYY-MM-DD\') AS date_value'));
+   assertEquals(true, $snowflakeSQL->contains('TO_TIMESTAMP(timestamp_string, \'YYYY-MM-DD HH24:MI:SS\') AS timestamp_value'));
+   
+   assertEquals(true, $duckdbSQL->contains('CAST(value AS INTEGER) AS int_value'));
+   assertEquals(true, $duckdbSQL->contains('CAST(string_value AS DOUBLE) AS numeric_value'));
+   assertEquals(true, $duckdbSQL->contains('TO_DATE(date_string, \'YYYY-MM-DD\') AS date_value'));
+   assertEquals(true, $duckdbSQL->contains('TO_TIMESTAMP(timestamp_string, \'YYYY-MM-DD HH24:MI:SS\') AS timestamp_value'));
+   
+   assertEquals(true, $bigquerySQL->contains('CAST(value AS INTEGER) AS int_value'));
+   assertEquals(true, $bigquerySQL->contains('CAST(string_value AS NUMERIC) AS numeric_value'));
+   assertEquals(true, $bigquerySQL->contains('PARSE_DATE(\'YYYY-MM-DD\', date_string) AS date_value'));
+   assertEquals(true, $bigquerySQL->contains('PARSE_TIMESTAMP(\'YYYY-MM-DD HH24:MI:SS\', timestamp_string) AS timestamp_value'));
+   
+   assertEquals(true, $databricksSQL->contains('CAST(value AS INTEGER) AS int_value'));
+   assertEquals(true, $databricksSQL->contains('CAST(string_value AS DECIMAL(38, 10)) AS numeric_value'));
+   assertEquals(true, $databricksSQL->contains('TO_DATE(date_string, \'YYYY-MM-DD\') AS date_value'));
+   assertEquals(true, $databricksSQL->contains('TO_TIMESTAMP(timestamp_string, \'YYYY-MM-DD HH24:MI:SS\') AS timestamp_value'));
+   
+   assertEquals(true, $redshiftSQL->contains('CAST(value AS INTEGER) AS int_value'));
+   assertEquals(true, $redshiftSQL->contains('TO_NUMBER(string_value) AS numeric_value'));
+   assertEquals(true, $redshiftSQL->contains('TO_DATE(date_string, \'YYYY-MM-DD\') AS date_value'));
+   assertEquals(true, $redshiftSQL->contains('TO_TIMESTAMP(timestamp_string, \'YYYY-MM-DD HH24:MI:SS\') AS timestamp_value'));
+   
+   assertEquals(true, $postgresSQL->contains('CAST(value AS INTEGER) AS int_value'));
+   assertEquals(true, $postgresSQL->contains('TO_NUMBER(string_value) AS numeric_value'));
+   assertEquals(true, $postgresSQL->contains('TO_DATE(date_string, \'YYYY-MM-DD\') AS date_value'));
+   assertEquals(true, $postgresSQL->contains('TO_TIMESTAMP(timestamp_string, \'YYYY-MM-DD HH24:MI:SS\') AS timestamp_value'));
+   
+   true;
+}
+
+function <<test.Test>> meta::pure::dsl::tests::testNewMathFunctions(): Boolean[1]
+{
+   // Create a DataFrame with new math functions
+   let df = select([
+      round(col('value'), literal(2))->as('rounded_value'),
+      ceiling(col('value'))->as('ceiling_value'),
+      floor(col('value'))->as('floor_value'),
+      log(col('value'))->as('log_value'),
+      ln(col('value'))->as('ln_value'),
+      mod(col('value'), literal(5))->as('mod_value')
+   ])
+   ->from(table('data'));
+   
+   // Test SQL generation across all supported databases
+   let snowflakeSQL = $df->generateSnowflakeSQL();
+   let duckdbSQL = $df->generateDuckDBSQL();
+   let bigquerySQL = $df->generateBigQuerySQL();
+   let databricksSQL = $df->generateDatabricksSQL();
+   let redshiftSQL = $df->generateRedshiftSQL();
+   let postgresSQL = $df->generatePostgresSQL();
+   
+   // Verify SQL contains expected syntax
+   assertEquals(true, $snowflakeSQL->contains('ROUND(value, 2) AS rounded_value'));
+   assertEquals(true, $snowflakeSQL->contains('CEILING(value) AS ceiling_value'));
+   assertEquals(true, $snowflakeSQL->contains('FLOOR(value) AS floor_value'));
+   assertEquals(true, $snowflakeSQL->contains('LOG(value) AS log_value'));
+   assertEquals(true, $snowflakeSQL->contains('LN(value) AS ln_value'));
+   assertEquals(true, $snowflakeSQL->contains('MOD(value, 5) AS mod_value'));
+   
+   assertEquals(true, $duckdbSQL->contains('ROUND(value, 2) AS rounded_value'));
+   assertEquals(true, $duckdbSQL->contains('CEILING(value) AS ceiling_value'));
+   assertEquals(true, $duckdbSQL->contains('FLOOR(value) AS floor_value'));
+   assertEquals(true, $duckdbSQL->contains('LOG10(value) AS log_value'));
+   assertEquals(true, $duckdbSQL->contains('LN(value) AS ln_value'));
+   assertEquals(true, $duckdbSQL->contains('MOD(value, 5) AS mod_value'));
+   
+   assertEquals(true, $bigquerySQL->contains('ROUND(value, 2) AS rounded_value'));
+   assertEquals(true, $bigquerySQL->contains('CEIL(value) AS ceiling_value'));
+   assertEquals(true, $bigquerySQL->contains('FLOOR(value) AS floor_value'));
+   assertEquals(true, $bigquerySQL->contains('LOG10(value) AS log_value'));
+   assertEquals(true, $bigquerySQL->contains('LN(value) AS ln_value'));
+   assertEquals(true, $bigquerySQL->contains('MOD(value, 5) AS mod_value'));
+   
+   assertEquals(true, $databricksSQL->contains('ROUND(value, 2) AS rounded_value'));
+   assertEquals(true, $databricksSQL->contains('CEILING(value) AS ceiling_value'));
+   assertEquals(true, $databricksSQL->contains('FLOOR(value) AS floor_value'));
+   assertEquals(true, $databricksSQL->contains('LOG10(value) AS log_value'));
+   assertEquals(true, $databricksSQL->contains('LN(value) AS ln_value'));
+   assertEquals(true, $databricksSQL->contains('MOD(value, 5) AS mod_value'));
+   
+   assertEquals(true, $redshiftSQL->contains('ROUND(value, 2) AS rounded_value'));
+   assertEquals(true, $redshiftSQL->contains('CEILING(value) AS ceiling_value'));
+   assertEquals(true, $redshiftSQL->contains('FLOOR(value) AS floor_value'));
+   assertEquals(true, $redshiftSQL->contains('LOG10(value) AS log_value'));
+   assertEquals(true, $redshiftSQL->contains('LN(value) AS ln_value'));
+   assertEquals(true, $redshiftSQL->contains('MOD(value, 5) AS mod_value'));
+   
+   assertEquals(true, $postgresSQL->contains('ROUND(value, 2) AS rounded_value'));
+   assertEquals(true, $postgresSQL->contains('CEILING(value) AS ceiling_value'));
+   assertEquals(true, $postgresSQL->contains('FLOOR(value) AS floor_value'));
+   assertEquals(true, $postgresSQL->contains('LOG10(value) AS log_value'));
+   assertEquals(true, $postgresSQL->contains('LN(value) AS ln_value'));
+   assertEquals(true, $postgresSQL->contains('MOD(value, 5) AS mod_value'));
+   
+   true;
+}
+
+function <<test.Test>> meta::pure::dsl::tests::testNewDateFunctions(): Boolean[1]
+{
+   // Create a DataFrame with new date functions
+   let df = select([
+      currentDate()->as('today'),
+      dateAdd(literal('day'), col('date_value'), literal(7))->as('date_plus_7_days'),
+      dateSub(literal('month'), col('date_value'), literal(1))->as('date_minus_1_month')
+   ])
+   ->from(table('data'));
+   
+   // Test SQL generation across all supported databases
+   let snowflakeSQL = $df->generateSnowflakeSQL();
+   let duckdbSQL = $df->generateDuckDBSQL();
+   let bigquerySQL = $df->generateBigQuerySQL();
+   let databricksSQL = $df->generateDatabricksSQL();
+   let redshiftSQL = $df->generateRedshiftSQL();
+   let postgresSQL = $df->generatePostgresSQL();
+   
+   // Verify SQL contains expected syntax
+   assertEquals(true, $snowflakeSQL->contains('CURRENT_DATE() AS today'));
+   assertEquals(true, $snowflakeSQL->contains('DATEADD(\'day\', 7, date_value) AS date_plus_7_days'));
+   assertEquals(true, $snowflakeSQL->contains('DATEADD(\'month\', -1, date_value) AS date_minus_1_month'));
+   
+   assertEquals(true, $duckdbSQL->contains('CURRENT_DATE() AS today'));
+   assertEquals(true, $duckdbSQL->contains('DATEADD(\'day\', 7, date_value) AS date_plus_7_days'));
+   assertEquals(true, $duckdbSQL->contains('DATEADD(\'month\', -1, date_value) AS date_minus_1_month'));
+   
+   assertEquals(true, $bigquerySQL->contains('CURRENT_DATE() AS today'));
+   assertEquals(true, $bigquerySQL->contains('DATE_ADD(\'day\', date_value, 7) AS date_plus_7_days'));
+   assertEquals(true, $bigquerySQL->contains('DATE_SUB(\'month\', date_value, 1) AS date_minus_1_month'));
+   
+   assertEquals(true, $databricksSQL->contains('CURRENT_DATE() AS today'));
+   assertEquals(true, $databricksSQL->contains('DATE_ADD(\'day\', date_value, 7) AS date_plus_7_days'));
+   assertEquals(true, $databricksSQL->contains('DATE_SUB(\'month\', date_value, 1) AS date_minus_1_month'));
+   
+   assertEquals(true, $redshiftSQL->contains('CURRENT_DATE() AS today'));
+   assertEquals(true, $redshiftSQL->contains('DATEADD(\'day\', 7, date_value) AS date_plus_7_days'));
+   assertEquals(true, $redshiftSQL->contains('DATEADD(\'month\', -1, date_value) AS date_minus_1_month'));
+   
+   assertEquals(true, $postgresSQL->contains('CURRENT_DATE() AS today'));
+   assertEquals(true, $postgresSQL->contains('(date_value + CAST(7 day AS INTERVAL)) AS date_plus_7_days'));
+   assertEquals(true, $postgresSQL->contains('(date_value - CAST(1 month AS INTERVAL)) AS date_minus_1_month'));
+   
+   true;
+}
+
+function <<test.Test>> meta::pure::dsl::tests::testNewStringFunctions(): Boolean[1]
+{
+   // Create a DataFrame with new string functions
+   let df = select([
+      left(col('name'), literal(3))->as('name_left_3'),
+      right(col('name'), literal(3))->as('name_right_3'),
+      split(col('full_name'), literal(' '))->as('name_parts'),
+      regexpExtract(col('text'), literal('\\d+'))->as('extracted_numbers')
+   ])
+   ->from(table('users'));
+   
+   // Test SQL generation across all supported databases
+   let snowflakeSQL = $df->generateSnowflakeSQL();
+   let duckdbSQL = $df->generateDuckDBSQL();
+   let bigquerySQL = $df->generateBigQuerySQL();
+   let databricksSQL = $df->generateDatabricksSQL();
+   let redshiftSQL = $df->generateRedshiftSQL();
+   let postgresSQL = $df->generatePostgresSQL();
+   
+   // Verify SQL contains expected syntax
+   assertEquals(true, $snowflakeSQL->contains('LEFT(name, 3) AS name_left_3'));
+   assertEquals(true, $snowflakeSQL->contains('RIGHT(name, 3) AS name_right_3'));
+   assertEquals(true, $snowflakeSQL->contains('SPLIT(full_name, \' \') AS name_parts'));
+   assertEquals(true, $snowflakeSQL->contains('REGEXP_SUBSTR(text, \'\\d+\', 1, 1) AS extracted_numbers'));
+   
+   assertEquals(true, $duckdbSQL->contains('LEFT(name, 3) AS name_left_3'));
+   assertEquals(true, $duckdbSQL->contains('RIGHT(name, 3) AS name_right_3'));
+   assertEquals(true, $duckdbSQL->contains('STRING_SPLIT(full_name, \' \') AS name_parts'));
+   assertEquals(true, $duckdbSQL->contains('REGEXP_EXTRACT(text, \'\\d+\') AS extracted_numbers'));
+   
+   assertEquals(true, $bigquerySQL->contains('LEFT(name, 3) AS name_left_3'));
+   assertEquals(true, $bigquerySQL->contains('RIGHT(name, 3) AS name_right_3'));
+   assertEquals(true, $bigquerySQL->contains('SPLIT(full_name, \' \') AS name_parts'));
+   assertEquals(true, $bigquerySQL->contains('REGEXP_EXTRACT(text, \'\\d+\') AS extracted_numbers'));
+   
+   assertEquals(true, $databricksSQL->contains('LEFT(name, 3) AS name_left_3'));
+   assertEquals(true, $databricksSQL->contains('RIGHT(name, 3) AS name_right_3'));
+   assertEquals(true, $databricksSQL->contains('SPLIT(full_name, \' \') AS name_parts'));
+   assertEquals(true, $databricksSQL->contains('REGEXP_EXTRACT(text, \'\\d+\') AS extracted_numbers'));
+   
+   assertEquals(true, $redshiftSQL->contains('LEFT(name, 3) AS name_left_3'));
+   assertEquals(true, $redshiftSQL->contains('RIGHT(name, 3) AS name_right_3'));
+   assertEquals(true, $redshiftSQL->contains('SPLIT_PART(full_name, \' \', 1) AS name_parts'));
+   assertEquals(true, $redshiftSQL->contains('REGEXP_SUBSTR(text, \'\\d+\', 1, 1) AS extracted_numbers'));
+   
+   assertEquals(true, $postgresSQL->contains('LEFT(name, 3) AS name_left_3'));
+   assertEquals(true, $postgresSQL->contains('RIGHT(name, 3) AS name_right_3'));
+   assertEquals(true, $postgresSQL->contains('STRING_TO_ARRAY(full_name, \' \') AS name_parts'));
+   assertEquals(true, $postgresSQL->contains('REGEXP_MATCHES(text, \'\\d+\')[1] AS extracted_numbers'));
+   
+   true;
+}
+
+function <<test.Test>> meta::pure::dsl::tests::testNestedNewFunctions(): Boolean[1]
+{
+   // Create a DataFrame with nested new functions
+   let df = select([
+      ceiling(round(col('value'), literal(2)))->as('ceiling_of_rounded'),
+      coalesce(nullif(col('value'), literal(0)), literal(1))->as('safe_value'),
+      left(upper(col('name')), literal(3))->as('upper_left_3')
+   ])
+   ->from(table('data'));
+   
+   // Test SQL generation across all supported databases
+   let snowflakeSQL = $df->generateSnowflakeSQL();
+   let duckdbSQL = $df->generateDuckDBSQL();
+   let bigquerySQL = $df->generateBigQuerySQL();
+   let databricksSQL = $df->generateDatabricksSQL();
+   let redshiftSQL = $df->generateRedshiftSQL();
+   let postgresSQL = $df->generatePostgresSQL();
+   
+   // Verify SQL contains expected nested function syntax
+   assertEquals(true, $snowflakeSQL->contains('CEILING(ROUND(value, 2)) AS ceiling_of_rounded'));
+   assertEquals(true, $snowflakeSQL->contains('COALESCE(NULLIF(value, 0), 1) AS safe_value'));
+   assertEquals(true, $snowflakeSQL->contains('LEFT(UPPER(name), 3) AS upper_left_3'));
+   
+   assertEquals(true, $duckdbSQL->contains('CEILING(ROUND(value, 2)) AS ceiling_of_rounded'));
+   assertEquals(true, $duckdbSQL->contains('COALESCE(NULLIF(value, 0), 1) AS safe_value'));
+   assertEquals(true, $duckdbSQL->contains('LEFT(UPPER(name), 3) AS upper_left_3'));
+   
+   assertEquals(true, $bigquerySQL->contains('CEIL(ROUND(value, 2)) AS ceiling_of_rounded'));
+   assertEquals(true, $bigquerySQL->contains('COALESCE(NULLIF(value, 0), 1) AS safe_value'));
+   assertEquals(true, $bigquerySQL->contains('LEFT(UPPER(name), 3) AS upper_left_3'));
+   
+   assertEquals(true, $databricksSQL->contains('CEILING(ROUND(value, 2)) AS ceiling_of_rounded'));
+   assertEquals(true, $databricksSQL->contains('COALESCE(NULLIF(value, 0), 1) AS safe_value'));
+   assertEquals(true, $databricksSQL->contains('LEFT(UPPER(name), 3) AS upper_left_3'));
+   
+   assertEquals(true, $redshiftSQL->contains('CEILING(ROUND(value, 2)) AS ceiling_of_rounded'));
+   assertEquals(true, $redshiftSQL->contains('COALESCE(NULLIF(value, 0), 1) AS safe_value'));
+   assertEquals(true, $redshiftSQL->contains('LEFT(UPPER(name), 3) AS upper_left_3'));
+   
+   assertEquals(true, $postgresSQL->contains('CEILING(ROUND(value, 2)) AS ceiling_of_rounded'));
+   assertEquals(true, $postgresSQL->contains('COALESCE(NULLIF(value, 0), 1) AS safe_value'));
+   assertEquals(true, $postgresSQL->contains('LEFT(UPPER(name), 3) AS upper_left_3'));
+   
+   true;
+}


### PR DESCRIPTION
# Add More Scalar Functions

This PR adds additional scalar functions to the legend-dataframe project, expanding the functionality across multiple categories:

## New Function Categories
- **Conditional Functions**: coalesce, nullif, greatest, least
- **Conversion Functions**: cast, toNumber, toDate, toTimestamp
- **Math Functions**: round, ceiling, floor, log, ln, mod
- **Date Functions**: currentDate, dateAdd, dateSub
- **String Functions**: left, right, split, regexpExtract

## Implementation Details
- All functions support 6 database dialects: Snowflake, DuckDB, BigQuery, Databricks, Redshift, and Postgres
- Database-specific syntax variations are handled through parameter transformations
- Comprehensive test suite for all new functions
- Modular implementation organized by function type

## Testing
- Added test cases for all new function categories
- Tests verify SQL generation across all supported database dialects
- Includes tests for nested function calls

Requested by: Neema Raphael

Link to Devin run: https://app.devin.ai/sessions/45004490a8a849a9828513257b729355