### PR TITLE
Remove custom operators in favor of Pure language built-ins

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ legend-dataframe/
 // Create a DataFrame from a table
 let df = table('employees');
 
-// Filter rows using type-safe filter function
-let filtered = $df->filter({x | $x.salary > 50000});
+// Filter rows using type-safe filter function with Pure built-ins
+let filtered = $df->filter({x | $x.salary > 50000 && $x.department == 'Engineering'});
 
 // Select specific columns
 let selected = $df->select({x | [~id, ~name, ~salary]});

--- a/src/main/resources/pure/dsl/dataframe/dataframe.pure
+++ b/src/main/resources/pure/dsl/dataframe/dataframe.pure
@@ -404,7 +404,16 @@ function meta::pure::dsl::dataframe::from(df: DataFrame[1], source: DataSource[1
    ^$df(source = $source)
 }
 
-// Type-safe filter function
+/**
+ * Type-safe filter function that takes a lambda expression. 
+ * Use Pure language built-ins for comparisons within the lambda instead of custom operators.
+ * Examples:
+ * - $df->filter({x | $x.salary > 50000})           // Greater than
+ * - $df->filter({x | $x.name == 'John'})           // Equals
+ * - $df->filter({x | $x.age != 30})                // Not equals
+ * - $df->filter({x | $x.dept == 'HR' && $x.age > 40}) // AND condition
+ * - $df->filter({x | $x.region == 'East' || $x.status == 'Active'}) // OR condition
+ */
 function meta::pure::dsl::dataframe::filter<T>(df: DataFrame[1], condition: Function<{T[1]->Boolean[1]}>[1]): DataFrame[1]
 {
    ^$df(filter = $condition)
@@ -541,66 +550,7 @@ function meta::pure::dsl::dataframe::as(expr: Expression[1], alias: String[1]): 
    ^Column(name = $alias, expression = $expr, alias = $alias)
 }
 
-// Helper functions for creating conditions
-function meta::pure::dsl::dataframe::eq(left: Expression[1], right: Expression[1]): BinaryOperation[1]
-{
-   ^BinaryOperation(left = $left, operator = BinaryOperator.EQUALS, right = $right)
-}
-
-function meta::pure::dsl::dataframe::neq(left: Expression[1], right: Expression[1]): BinaryOperation[1]
-{
-   ^BinaryOperation(left = $left, operator = BinaryOperator.NOT_EQUALS, right = $right)
-}
-
-function meta::pure::dsl::dataframe::gt(left: Expression[1], right: Expression[1]): BinaryOperation[1]
-{
-   ^BinaryOperation(left = $left, operator = BinaryOperator.GREATER_THAN, right = $right)
-}
-
-function meta::pure::dsl::dataframe::lt(left: Expression[1], right: Expression[1]): BinaryOperation[1]
-{
-   ^BinaryOperation(left = $left, operator = BinaryOperator.LESS_THAN, right = $right)
-}
-
-function meta::pure::dsl::dataframe::gte(left: Expression[1], right: Expression[1]): BinaryOperation[1]
-{
-   ^BinaryOperation(left = $left, operator = BinaryOperator.GREATER_THAN_OR_EQUALS, right = $right)
-}
-
-function meta::pure::dsl::dataframe::lte(left: Expression[1], right: Expression[1]): BinaryOperation[1]
-{
-   ^BinaryOperation(left = $left, operator = BinaryOperator.LESS_THAN_OR_EQUALS, right = $right)
-}
-
-function meta::pure::dsl::dataframe::and(left: FilterCondition[1], right: FilterCondition[1]): BinaryOperation[1]
-{
-   ^BinaryOperation(left = $left, operator = BinaryOperator.AND, right = $right)
-}
-
-function meta::pure::dsl::dataframe::or(left: FilterCondition[1], right: FilterCondition[1]): BinaryOperation[1]
-{
-   ^BinaryOperation(left = $left, operator = BinaryOperator.OR, right = $right)
-}
-
-function meta::pure::dsl::dataframe::not(expr: FilterCondition[1]): UnaryOperation[1]
-{
-   ^UnaryOperation(operator = UnaryOperator.NOT, expression = $expr)
-}
-
-function meta::pure::dsl::dataframe::like(expr: Expression[1], pattern: String[1]): BinaryOperation[1]
-{
-   ^BinaryOperation(left = $expr, operator = BinaryOperator.LIKE, right = ^LiteralExpression(value = $pattern))
-}
-
-function meta::pure::dsl::dataframe::isNull(expr: Expression[1]): BinaryOperation[1]
-{
-   ^BinaryOperation(left = $expr, operator = BinaryOperator.IS_NULL, right = ^LiteralExpression(value = 'null'))
-}
-
-function meta::pure::dsl::dataframe::isNotNull(expr: Expression[1]): BinaryOperation[1]
-{
-   ^BinaryOperation(left = $expr, operator = BinaryOperator.IS_NOT_NULL, right = ^LiteralExpression(value = 'null'))
-}
+// Helper functions for creating data sources
 
 // Helper functions for creating data sources
 function meta::pure::dsl::dataframe::table(name: String[1]): TableReference[1]

--- a/src/main/resources/pure/dsl/dataframe/dataframe.pure
+++ b/src/main/resources/pure/dsl/dataframe/dataframe.pure
@@ -426,11 +426,7 @@ function meta::pure::dsl::dataframe::filter<T>(df: DataFrame[1], tableSchema: Ta
    ^$df(filter = $condition)
 }
 
-// For backward compatibility (deprecated)
-function meta::pure::dsl::dataframe::where(df: DataFrame[1], condition: FilterCondition[1]): DataFrame[1]
-{
-   filter($df, {x | $condition})
-}
+// where() function has been removed in favor of filter()
 
 // Type-safe groupBy functions
 function meta::pure::dsl::dataframe::groupBy<T, Z>(df: DataFrame[1], cols: ColSpecArray<Z>[1]): DataFrame[1]

--- a/src/main/resources/pure/dsl/examples/basic_operations.pure
+++ b/src/main/resources/pure/dsl/examples/basic_operations.pure
@@ -19,7 +19,7 @@ function meta::pure::dsl::examples::basicOperations(): Any[*]
    // Create a DataFrame from a table
    let employees = table('employees');
    
-   // Filter rows using type-safe filter function with lambda
+   // Filter rows using type-safe filter function with lambda and Pure built-ins
    let highPaid = $employees->filter({e | $e.salary > 50000});
    
    // Select specific columns using tilde notation

--- a/src/test/resources/pure/dsl/tests/bigquery_qualify_tests.pure
+++ b/src/test/resources/pure/dsl/tests/bigquery_qualify_tests.pure
@@ -27,7 +27,7 @@ function <<meta::pure::profiles::test.Test>> {meta.pure.profiles.test.AlloyOnly}
       as(col('salary'), 'salary')
    ])
    ->from(table('employees'))
-   ->qualify(lt($windowFunc, 3));
+   ->qualify({x | $windowFunc < 3});
    
    // Test SQL generation using toBigQuerySQL
    let sql = $df->toBigQuerySQL();

--- a/src/test/resources/pure/dsl/tests/databricks_tests.pure
+++ b/src/test/resources/pure/dsl/tests/databricks_tests.pure
@@ -27,7 +27,7 @@ function <<meta::pure::profiles::test.Test>> {meta.pure.profiles.test.AlloyOnly}
       as(col('salary'), 'salary')
    ])
    ->from(table('employees'))
-   ->qualify(lt($windowFunc, 3));
+   ->qualify({x | $windowFunc < 3});
    
    // Test SQL generation
    let sql = $df->toSQL(Database.DATABRICKS);

--- a/src/test/resources/pure/dsl/tests/dataframe_tests.pure
+++ b/src/test/resources/pure/dsl/tests/dataframe_tests.pure
@@ -45,11 +45,11 @@ function <<test.Test>> meta::pure::dsl::tests::testSimpleSelect(): Boolean[1]
 
 function <<test.Test>> meta::pure::dsl::tests::testSelectWithFilter(): Boolean[1]
 {
-   // Create a SELECT query with WHERE clause
+   // Create a SELECT query with filter using Pure built-ins
    let df = select([
       as(col('id'), 'id'),
       as(col('name'), 'name')
-   ])->from(table('customers'))->where(eq(col('id'), literal(100)));
+   ])->from(table('customers'))->filter({x | $x.id == 100});
    
    // Generate SQL for Snowflake
    let snowflakeSQL = $df->generateSnowflakeSQL();
@@ -73,7 +73,7 @@ function <<test.Test>> meta::pure::dsl::tests::testSelectWithJoin(): Boolean[1]
       join(
          tableAs('customers', 'c'),
          tableAs('orders', 'o'),
-         eq(col('c', 'id'), col('o', 'customer_id'))
+         {c, o | $c.id == $o.customer_id}
       )
    );
    
@@ -157,18 +157,11 @@ function <<test.Test>> meta::pure::dsl::tests::testComplexQuery(): Boolean[1]
       leftJoin(
          tableAs('categories', 'c'),
          tableAs('orders', 'o'),
-         eq(col('c', 'id'), col('o', 'category_id'))
+         {c, o | $c.id == $o.category_id}
       )
-   )->where(
-      and(
-         gt(col('o', 'amount'), literal(100)),
-         isNotNull(col('o', 'customer_id'))
-      )
-   )->groupBy([
+   )->filter({x | $x.o.amount > 100 && $x.o.customer_id != null})->groupBy([
       col('c', 'category')
-   ])->having(
-      gt(count(col('o', 'id')), literal(5))
-   )->orderBy([
+   ])->having({x | count(col('o', 'id')) > 5})->orderBy([
       desc(sum(col('o', 'amount')))
    ])->limit(5);
    
@@ -208,7 +201,7 @@ function <<test.Test>> meta::pure::dsl::tests::testDatabaseSpecificSyntaxDiffere
       leftJoin(
          tableAs('customers', 'c'),
          tableAs('orders', 'o'),
-         eq(col('c', 'id'), col('o', 'customer_id'))
+         {c, o | $c.id == $o.customer_id}
       )
    );
    

--- a/src/test/resources/pure/dsl/tests/dataframe_tests.pure
+++ b/src/test/resources/pure/dsl/tests/dataframe_tests.pure
@@ -428,7 +428,7 @@ function <<test.Test>> meta::pure::dsl::tests::testCommonTableExpressions(): Boo
       table('customers', 'c'),
       table('orders', 'o'),
       JoinType.INNER,
-      eq(col('c', 'id'), col('o', 'customer_id'))
+      {c, o | $c.id == $o.customer_id}
    ))
    ->groupBy([col('c', 'name')])
    ->with([$customerCte, $orderCte]);
@@ -454,7 +454,7 @@ function <<test.Test>> meta::pure::dsl::tests::testDatabricksSQL(): Boolean[1]
    let df = select([
       as(col('c', 'name'), 'customer_name'),
       as(col('c', 'age'), 'customer_age')
-   ])->from(tableAs('customers', 'c'))->where(gt(col('c', 'age'), literal(30)));
+   ])->from(tableAs('customers', 'c'))->filter({x | $x.c.age > 30});
    
    // Generate Databricks SQL
    let databricksSQL = $df->generateDatabricksSQL();
@@ -481,7 +481,7 @@ function <<test.Test>> meta::pure::dsl::tests::testDatabricksQualify(): Boolean[
       as(rowNumber()->over(partitionBy([col('c', 'region')]), orderBy([desc(col('c', 'sales'))])), 'sales_rank')
    ])
    ->from(tableAs('customers', 'c'))
-   ->qualify(lte(col('sales_rank'), literal(3))); // Only keep top 3 customers by sales in each region
+   ->qualify({x | $x.sales_rank <= 3}); // Only keep top 3 customers by sales in each region
    
    // Generate Databricks SQL
    let databricksSQL = $df->generateDatabricksSQL();

--- a/src/test/resources/pure/dsl/tests/postgres_tests.pure
+++ b/src/test/resources/pure/dsl/tests/postgres_tests.pure
@@ -203,7 +203,7 @@ function <<test.Test>> meta::pure::dsl::tests::testPostgresWithCTE(): Boolean[1]
    ->from(join(
       tableAs('customers', 'c'),
       tableAs('orders', 'o'),
-      eq(col('c', 'id'), col('o', 'customer_id'))
+      {c, o | $c.id == $o.customer_id}
    ))
    ->groupBy([col('c', 'name')])
    ->with([$customerCte, $orderCte]);

--- a/src/test/resources/pure/dsl/tests/postgres_tests.pure
+++ b/src/test/resources/pure/dsl/tests/postgres_tests.pure
@@ -38,11 +38,11 @@ function <<test.Test>> meta::pure::dsl::tests::testPostgresSimpleSelect(): Boole
 
 function <<test.Test>> meta::pure::dsl::tests::testPostgresSelectWithFilter(): Boolean[1]
 {
-   // Create a SELECT query with WHERE clause
+   // Create a SELECT query with filter using Pure built-ins
    let df = select([
       as(col('id'), 'id'),
       as(col('name'), 'name')
-   ])->from(table('customers'))->where(eq(col('id'), literal(100)));
+   ])->from(table('customers'))->filter({x | $x.id == 100});
    
    // Generate SQL for PostgreSQL
    let postgresSQL = $df->generatePostgresSQL();
@@ -62,7 +62,7 @@ function <<test.Test>> meta::pure::dsl::tests::testPostgresSelectWithJoin(): Boo
       join(
          tableAs('customers', 'c'),
          tableAs('orders', 'o'),
-         eq(col('c', 'id'), col('o', 'customer_id'))
+         {c, o | $c.id == $o.customer_id}
       )
    );
    
@@ -130,18 +130,11 @@ function <<test.Test>> meta::pure::dsl::tests::testPostgresComplexQuery(): Boole
       leftJoin(
          tableAs('categories', 'c'),
          tableAs('orders', 'o'),
-         eq(col('c', 'id'), col('o', 'category_id'))
+         {c, o | $c.id == $o.category_id}
       )
-   )->where(
-      and(
-         gt(col('o', 'amount'), literal(100)),
-         isNotNull(col('o', 'customer_id'))
-      )
-   )->groupBy([
+   )->filter({x | $x.o.amount > 100 && $x.o.customer_id != null})->groupBy([
       col('c', 'category')
-   ])->having(
-      gt(count(col('o', 'id')), literal(5))
-   )->orderBy([
+   ])->having({x | count(col('o', 'id')) > 5})->orderBy([
       desc(sum(col('o', 'amount')))
    ])->limit(5);
    
@@ -170,7 +163,7 @@ function <<test.Test>> meta::pure::dsl::tests::testPostgresLateralJoin(): Boolea
          tableAs('customers', 'c'),
          select([as(col('value'), 'value')])->from(table('orders')),
          'o',
-         eq(col('c', 'id'), col('o', 'customer_id'))
+         {c, o | $c.id == $o.customer_id}
       )
    );
    

--- a/src/test/resources/pure/dsl/tests/typesafe_tests.pure
+++ b/src/test/resources/pure/dsl/tests/typesafe_tests.pure
@@ -165,10 +165,10 @@ function <<test.Test>> meta::pure::dsl::tests::testTypeSafeFilter(): Boolean[1]
    // Create a table with schema
    let productsTable = tableWithSchema('products', $productSchema);
    
-   // Test filter with type-safe columns
+   // Test filter with type-safe columns using Pure built-ins
    let df = select(~($productSchema, ['id', 'name', 'price']))
       ->from($productsTable)
-      ->where(eq(~($productSchema, 'category'), literal('Electronics')));
+      ->filter({x | $x.category == 'Electronics'});
    
    // Generate SQL for Snowflake and verify
    let snowflakeSQL = $df->generateSnowflakeSQL();
@@ -299,7 +299,7 @@ function <<test.Test>> meta::pure::dsl::tests::testTypeSafeJoin(): Boolean[1]
       $ordersDf, 
       $customersDf, 
       JoinType.INNER, 
-      eq(col('o', 'customer_id'), col('c', 'id'))
+      {o, c | $o.customer_id == $c.id}
    );
    
    // Generate SQL for Snowflake and verify


### PR DESCRIPTION
# Update filtering to use Pure language built-ins

- Modified the DSL filtering functionality to exclusively use lambda expressions with Pure language built-ins for filtering operations
- Removed custom comparison operators (eq, neq, gt, lt, etc.)
- Removed where() function in favor of filter()
- Updated documentation and examples to demonstrate the new approach
- Updated tests to use the new approach

Link to Devin run: https://app.devin.ai/sessions/49efb237b77b4b1da4147e426e4cd968
Requested by: neema.raphael@gs.com