### PR TITLE
Replace col() with tilde notation and update ColumnReference to use ColSpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ DataFrame supports window functions using the `over` function:
 // Basic window function with partition by
 let avgSalaryByDept = $df
    ->extend([
-      avg(col('salary'))->over(~department)->as('avg_salary')
+      avg(~salary)->over(~department)->as('avg_salary')
    ]);
 
 // Window function with ordering
@@ -101,7 +101,7 @@ let salaryRank = $df
 // Window function with frame
 let runningTotal = $df
    ->extend([
-      sum(col('amount'))->over([~department], [asc(~date)], rows(unbounded(), 0))->as('running_total')
+      sum(~amount)->over([~department], [asc(~date)], rows(unbounded(), 0))->as('running_total')
    ]);
 ```
 

--- a/examples/comprehensive_example.pure
+++ b/examples/comprehensive_example.pure
@@ -59,14 +59,14 @@ function meta::pure::dsl::examples::comprehensiveExample(): String[1]
    // Create CTEs for monthly sales aggregation
    let monthlySalesCte = cte('monthly_sales',
       select([
-         as(extract('MONTH', col('order_date')), 'month'),
-         as(extract('YEAR', col('order_date')), 'year'),
-         as(sum(col('amount')), 'monthly_total')
+         as(extract('MONTH', ~order_date), 'month'),
+         as(extract('YEAR', ~order_date), 'year'),
+         as(sum(~amount), 'monthly_total')
       ])
       ->from(tableWithSchema('orders', $orderSchema))
       ->groupBy([
-         extract('MONTH', col('order_date')),
-         extract('YEAR', col('order_date'))
+         extract('MONTH', ~order_date),
+         extract('YEAR', ~order_date)
       ])
    );
    
@@ -98,17 +98,17 @@ function meta::pure::dsl::examples::comprehensiveExample(): String[1]
    
    // Main query using CTEs and window functions
    let df = select([
-      as(col('cr', 'customer_name'), 'customer'),
-      as(col('cr', 'region'), 'region'),
-      as(col('cr', 'total_spent'), 'total_spent'),
-      as(col('cr', 'rank_in_region'), 'regional_rank'),
-      as(col('ms', 'month'), 'month'),
-      as(col('ms', 'year'), 'year'),
-      as(col('ms', 'monthly_total'), 'monthly_sales'),
+      as(~('cr', 'customer_name'), 'customer'),
+      as(~('cr', 'region'), 'region'),
+      as(~('cr', 'total_spent'), 'total_spent'),
+      as(~('cr', 'rank_in_region'), 'regional_rank'),
+      as(~('ms', 'month'), 'month'),
+      as(~('ms', 'year'), 'year'),
+      as(~('ms', 'monthly_total'), 'monthly_sales'),
       as(over(
-         avg(col('ms', 'monthly_total')), 
-         partitionBy([col('cr', 'region')])
-            ->orderBy([asc(col('ms', 'year')), asc(col('ms', 'month'))])
+         avg(~('ms', 'monthly_total')), 
+         partitionBy([~('cr', 'region')])
+            ->orderBy([asc(~('ms', 'year')), asc(~('ms', 'month'))])
             ->rowsBetween(preceding(2), currentRow())
       ), 'three_month_moving_avg')
    ])
@@ -120,14 +120,14 @@ function meta::pure::dsl::examples::comprehensiveExample(): String[1]
    ))
    ->where(
       and([
-         eq(col('cr', 'rank_in_region'), literal(1)),
-         lt(col('ms', 'monthly_total'), literal(10000))
+         eq(~('cr', 'rank_in_region'), literal(1)),
+         lt(~('ms', 'monthly_total'), literal(10000))
       ])
    )
    ->orderBy([
-      asc(col('cr', 'region')),
-      asc(col('ms', 'year')),
-      asc(col('ms', 'month'))
+      asc(~('cr', 'region')),
+      asc(~('ms', 'year')),
+      asc(~('ms', 'month'))
    ])
    ->with([$monthlySalesCte, $customerRankingCte]);
    

--- a/src/main/resources/pure/dsl/bigquery/bigquery.pure
+++ b/src/main/resources/pure/dsl/bigquery/bigquery.pure
@@ -204,7 +204,7 @@ function <<access.private>> meta::pure::dsl::bigquery::generateAggregationThresh
 function <<access.private>> meta::pure::dsl::bigquery::generateBigQueryExpression(column: Column[1]): String[1]
 {
    $column->match([
-      c: ColumnReference[1] | $c.name,
+      c: ColumnReference[1] | $c.colSpec.name,
       c: LiteralColumn[1] | generateBigQueryLiteral($c.value),
       c: FunctionColumn[1] | generateBigQueryFunction($c),
       c: CaseColumn[1] | generateBigQueryCase($c),

--- a/src/main/resources/pure/dsl/dataframe/dataframe.pure
+++ b/src/main/resources/pure/dsl/dataframe/dataframe.pure
@@ -365,7 +365,7 @@ function meta::pure::dsl::dataframe::newDataFrame(): DataFrame[1]
 function meta::pure::dsl::dataframe::select<T>(cols: ColSpecArray<T>[1]): DataFrame[1]
 {
    // Create columns from ColSpecArray
-   let columns = $cols.names->map(n | ^Column(name = $n, expression = ^ColumnReference(colSpec = ^ColSpec<Any>(name = $n)), alias = $n));
+   let columns = $cols.names->map(n | ^Column(name = $n, expression = ^ColumnReference(colSpec = ^ColSpec<T>(name = $n, tableSchema = $cols.tableSchema)), alias = $n));
    
    ^DataFrame(columns = $columns, distinct = false);
 }
@@ -373,7 +373,7 @@ function meta::pure::dsl::dataframe::select<T>(cols: ColSpecArray<T>[1]): DataFr
 function meta::pure::dsl::dataframe::select<T>(col: ColSpec<T>[1]): DataFrame[1]
 {
    // Create column from ColSpec
-   let column = ^Column(name = $col.name, expression = ^ColumnReference(colSpec = ^ColSpec<Any>(name = $col.name)), alias = $col.name);
+   let column = ^Column(name = $col.name, expression = ^ColumnReference(colSpec = $col), alias = $col.name);
    
    ^DataFrame(columns = [$column], distinct = false);
 }
@@ -387,7 +387,7 @@ function meta::pure::dsl::dataframe::select(columns: Column[*]): DataFrame[1]
 function meta::pure::dsl::dataframe::selectDistinct<T>(cols: ColSpecArray<T>[1]): DataFrame[1]
 {
    // Create columns from ColSpecArray
-   let columns = $cols.names->map(n | ^Column(name = $n, expression = ^ColumnReference(colSpec = ^ColSpec<Any>(name = $n)), alias = $n));
+   let columns = $cols.names->map(n | ^Column(name = $n, expression = ^ColumnReference(colSpec = ^ColSpec<T>(name = $n, tableSchema = $cols.tableSchema)), alias = $n));
    
    ^DataFrame(columns = $columns, distinct = true);
 }
@@ -395,7 +395,7 @@ function meta::pure::dsl::dataframe::selectDistinct<T>(cols: ColSpecArray<T>[1])
 function meta::pure::dsl::dataframe::selectDistinct<T>(col: ColSpec<T>[1]): DataFrame[1]
 {
    // Create column from ColSpec
-   let column = ^Column(name = $col.name, expression = ^ColumnReference(colSpec = ^ColSpec<Any>(name = $col.name)), alias = $col.name);
+   let column = ^Column(name = $col.name, expression = ^ColumnReference(colSpec = $col), alias = $col.name);
    
    ^DataFrame(columns = [$column], distinct = true);
 }
@@ -438,7 +438,7 @@ function meta::pure::dsl::dataframe::filter<T>(df: DataFrame[1], tableSchema: Ta
 function meta::pure::dsl::dataframe::groupBy<T, Z>(df: DataFrame[1], cols: ColSpecArray<Z>[1]): DataFrame[1]
 {
    // Create column references from ColSpecArray
-   let colRefs = $cols.names->map(n | ^ColumnReference(colSpec = ^ColSpec<Any>(name = $n)));
+   let colRefs = $cols.names->map(n | ^ColumnReference(colSpec = ^ColSpec<Z>(name = $n, tableSchema = $cols.tableSchema)));
    
    ^$df(groupBy = ^GroupByClause(columns = $colRefs));
 }
@@ -446,7 +446,7 @@ function meta::pure::dsl::dataframe::groupBy<T, Z>(df: DataFrame[1], cols: ColSp
 function meta::pure::dsl::dataframe::groupBy<T, Z>(df: DataFrame[1], col: ColSpec<Z>[1]): DataFrame[1]
 {
    // Create column reference
-   let colRef = ^ColumnReference(colSpec = ^ColSpec<Any>(name = $col.name));
+   let colRef = ^ColumnReference(colSpec = $col);
    
    ^$df(groupBy = ^GroupByClause(columns = [$colRef]));
 }
@@ -482,7 +482,7 @@ function meta::pure::dsl::dataframe::orderBy<T, Z>(df: DataFrame[1], cols: ColSp
 {
    let direction = if($desc->isNotEmpty() && $desc->toOne(), |SortDirection.DESC, |SortDirection.ASC);
    let clauses = $cols.names->map(n | ^OrderByClause(
-      expression = ^ColumnReference(colSpec = ^ColSpec<Any>(name = $n)),
+      expression = ^ColumnReference(colSpec = ^ColSpec<Z>(name = $n, tableSchema = $cols.tableSchema)),
       direction = $direction
    ));
    ^$df(orderBy = $clauses);
@@ -492,7 +492,7 @@ function meta::pure::dsl::dataframe::orderBy<T, Z>(df: DataFrame[1], col: ColSpe
 {
    let direction = if($desc->isNotEmpty() && $desc->toOne(), |SortDirection.DESC, |SortDirection.ASC);
    let clause = ^OrderByClause(
-      expression = ^ColumnReference(colSpec = ^ColSpec<Any>(name = $col.name)),
+      expression = ^ColumnReference(colSpec = $col),
       direction = $direction
    );
    ^$df(orderBy = [$clause]);
@@ -507,10 +507,10 @@ function meta::pure::dsl::dataframe::orderBy<T, Z>(df: DataFrame[1], tableSchema
       {
          let direction = if($desc->isNotEmpty() && $desc->toOne(), |SortDirection.DESC, |SortDirection.ASC);
          let clauses = $cols.names->map(n | ^OrderByClause(
-            expression = ^ColumnReference(colSpec = ^ColSpec<Any>(name = $n)),
+            expression = ^ColumnReference(colSpec = ^ColSpec<Z>(name = $n, tableSchema = $cols.tableSchema)),
             direction = $direction
-         ));
-         ^$df(orderBy = $clauses);
+          ));
+          ^$df(orderBy = $clauses);
       },
       error('Columns [' + $invalidColumns->joinStrings(', ') + '] not found in table schema "' + $tableSchema.name + '"')
    );

--- a/src/main/resources/pure/dsl/dataframe/dataframe.pure
+++ b/src/main/resources/pure/dsl/dataframe/dataframe.pure
@@ -80,7 +80,7 @@ Class meta::pure::dsl::dataframe::metamodel::LiteralExpression extends Expressio
 // Column reference expression
 Class meta::pure::dsl::dataframe::metamodel::ColumnReference extends Expression
 {
-   columnName : String[1];
+   colSpec : ColSpec<Any>[1];
    tableAlias : String[0..1];
 }
 
@@ -224,6 +224,12 @@ function meta::pure::dsl::dataframe::~(names:String[*]):ColSpecArray<Any>[1]
     ^ColSpecArray<Any>(names=$names);
 }
 
+// Tilde notation for table aliases
+function meta::pure::dsl::dataframe::~(tableName: String[1], columnName: String[1]): ColumnReference[1]
+{
+   ^ColumnReference(colSpec = ^ColSpec<Any>(name = $columnName), tableAlias = $tableName)
+}
+
 // Table-aware tilde notation for single column reference
 function meta::pure::dsl::dataframe::~<T>(schema: TableSchema<T>[1], name: String[1]): ColSpec<T>[1]
 {
@@ -359,7 +365,7 @@ function meta::pure::dsl::dataframe::newDataFrame(): DataFrame[1]
 function meta::pure::dsl::dataframe::select<T>(cols: ColSpecArray<T>[1]): DataFrame[1]
 {
    // Create columns from ColSpecArray
-   let columns = $cols.names->map(n | ^Column(name = $n, expression = ^ColumnReference(columnName = $n), alias = $n));
+   let columns = $cols.names->map(n | ^Column(name = $n, expression = ^ColumnReference(colSpec = ^ColSpec<Any>(name = $n)), alias = $n));
    
    ^DataFrame(columns = $columns, distinct = false);
 }
@@ -367,7 +373,7 @@ function meta::pure::dsl::dataframe::select<T>(cols: ColSpecArray<T>[1]): DataFr
 function meta::pure::dsl::dataframe::select<T>(col: ColSpec<T>[1]): DataFrame[1]
 {
    // Create column from ColSpec
-   let column = ^Column(name = $col.name, expression = ^ColumnReference(columnName = $col.name), alias = $col.name);
+   let column = ^Column(name = $col.name, expression = ^ColumnReference(colSpec = ^ColSpec<Any>(name = $col.name)), alias = $col.name);
    
    ^DataFrame(columns = [$column], distinct = false);
 }
@@ -381,7 +387,7 @@ function meta::pure::dsl::dataframe::select(columns: Column[*]): DataFrame[1]
 function meta::pure::dsl::dataframe::selectDistinct<T>(cols: ColSpecArray<T>[1]): DataFrame[1]
 {
    // Create columns from ColSpecArray
-   let columns = $cols.names->map(n | ^Column(name = $n, expression = ^ColumnReference(columnName = $n), alias = $n));
+   let columns = $cols.names->map(n | ^Column(name = $n, expression = ^ColumnReference(colSpec = ^ColSpec<Any>(name = $n)), alias = $n));
    
    ^DataFrame(columns = $columns, distinct = true);
 }
@@ -389,7 +395,7 @@ function meta::pure::dsl::dataframe::selectDistinct<T>(cols: ColSpecArray<T>[1])
 function meta::pure::dsl::dataframe::selectDistinct<T>(col: ColSpec<T>[1]): DataFrame[1]
 {
    // Create column from ColSpec
-   let column = ^Column(name = $col.name, expression = ^ColumnReference(columnName = $col.name), alias = $col.name);
+   let column = ^Column(name = $col.name, expression = ^ColumnReference(colSpec = ^ColSpec<Any>(name = $col.name)), alias = $col.name);
    
    ^DataFrame(columns = [$column], distinct = true);
 }
@@ -432,7 +438,7 @@ function meta::pure::dsl::dataframe::filter<T>(df: DataFrame[1], tableSchema: Ta
 function meta::pure::dsl::dataframe::groupBy<T, Z>(df: DataFrame[1], cols: ColSpecArray<Z>[1]): DataFrame[1]
 {
    // Create column references from ColSpecArray
-   let colRefs = $cols.names->map(n | ^ColumnReference(columnName = $n));
+   let colRefs = $cols.names->map(n | ^ColumnReference(colSpec = ^ColSpec<Any>(name = $n)));
    
    ^$df(groupBy = ^GroupByClause(columns = $colRefs));
 }
@@ -440,7 +446,7 @@ function meta::pure::dsl::dataframe::groupBy<T, Z>(df: DataFrame[1], cols: ColSp
 function meta::pure::dsl::dataframe::groupBy<T, Z>(df: DataFrame[1], col: ColSpec<Z>[1]): DataFrame[1]
 {
    // Create column reference
-   let colRef = ^ColumnReference(columnName = $col.name);
+   let colRef = ^ColumnReference(colSpec = ^ColSpec<Any>(name = $col.name));
    
    ^$df(groupBy = ^GroupByClause(columns = [$colRef]));
 }
@@ -453,7 +459,7 @@ function meta::pure::dsl::dataframe::groupBy<T, Z>(df: DataFrame[1], tableSchema
    if($invalidColumns->isEmpty(),
       {
          // Create column references from ColSpecArray
-         let colRefs = $cols.names->map(n | ^ColumnReference(columnName = $n));
+         let colRefs = $cols.names->map(n | ^ColumnReference(colSpec = ^ColSpec<Any>(name = $n)));
          
          ^$df(groupBy = ^GroupByClause(columns = $colRefs));
       },
@@ -476,7 +482,7 @@ function meta::pure::dsl::dataframe::orderBy<T, Z>(df: DataFrame[1], cols: ColSp
 {
    let direction = if($desc->isNotEmpty() && $desc->toOne(), |SortDirection.DESC, |SortDirection.ASC);
    let clauses = $cols.names->map(n | ^OrderByClause(
-      expression = ^ColumnReference(columnName = $n),
+      expression = ^ColumnReference(colSpec = ^ColSpec<Any>(name = $n)),
       direction = $direction
    ));
    ^$df(orderBy = $clauses);
@@ -486,7 +492,7 @@ function meta::pure::dsl::dataframe::orderBy<T, Z>(df: DataFrame[1], col: ColSpe
 {
    let direction = if($desc->isNotEmpty() && $desc->toOne(), |SortDirection.DESC, |SortDirection.ASC);
    let clause = ^OrderByClause(
-      expression = ^ColumnReference(columnName = $col.name),
+      expression = ^ColumnReference(colSpec = ^ColSpec<Any>(name = $col.name)),
       direction = $direction
    );
    ^$df(orderBy = [$clause]);
@@ -501,7 +507,7 @@ function meta::pure::dsl::dataframe::orderBy<T, Z>(df: DataFrame[1], tableSchema
       {
          let direction = if($desc->isNotEmpty() && $desc->toOne(), |SortDirection.DESC, |SortDirection.ASC);
          let clauses = $cols.names->map(n | ^OrderByClause(
-            expression = ^ColumnReference(columnName = $n),
+            expression = ^ColumnReference(colSpec = ^ColSpec<Any>(name = $n)),
             direction = $direction
          ));
          ^$df(orderBy = $clauses);
@@ -526,15 +532,7 @@ function meta::pure::dsl::dataframe::offset(df: DataFrame[1], offset: Integer[1]
 }
 
 // Helper functions for creating expressions
-function meta::pure::dsl::dataframe::col(name: String[1]): ColumnReference[1]
-{
-   ^ColumnReference(columnName = $name)
-}
-
-function meta::pure::dsl::dataframe::col(tableName: String[1], columnName: String[1]): ColumnReference[1]
-{
-   ^ColumnReference(columnName = $columnName, tableAlias = $tableName)
-}
+// col() functions have been removed in favor of tilde notation
 
 function meta::pure::dsl::dataframe::literal(value: Any[1]): LiteralExpression[1]
 {
@@ -614,7 +612,17 @@ function meta::pure::dsl::dataframe::join(left: DataSource[1], right: DataSource
    ^JoinOperation(left = $left, right = $right, joinType = JoinType.INNER, condition = $condition)
 }
 
+function meta::pure::dsl::dataframe::join<T, V>(left: DataSource[1], right: DataSource[1], condition: Function<{T[1], V[1]->Boolean[1]}>[1]): JoinOperation[1]
+{
+   ^JoinOperation(left = $left, right = $right, joinType = JoinType.INNER, condition = $condition)
+}
+
 function meta::pure::dsl::dataframe::leftJoin(left: DataSource[1], right: DataSource[1], condition: FilterCondition[1]): JoinOperation[1]
+{
+   ^JoinOperation(left = $left, right = $right, joinType = JoinType.LEFT_OUTER, condition = $condition)
+}
+
+function meta::pure::dsl::dataframe::leftJoin<T, V>(left: DataSource[1], right: DataSource[1], condition: Function<{T[1], V[1]->Boolean[1]}>[1]): JoinOperation[1]
 {
    ^JoinOperation(left = $left, right = $right, joinType = JoinType.LEFT_OUTER, condition = $condition)
 }
@@ -624,7 +632,17 @@ function meta::pure::dsl::dataframe::rightJoin(left: DataSource[1], right: DataS
    ^JoinOperation(left = $left, right = $right, joinType = JoinType.RIGHT_OUTER, condition = $condition)
 }
 
+function meta::pure::dsl::dataframe::rightJoin<T, V>(left: DataSource[1], right: DataSource[1], condition: Function<{T[1], V[1]->Boolean[1]}>[1]): JoinOperation[1]
+{
+   ^JoinOperation(left = $left, right = $right, joinType = JoinType.RIGHT_OUTER, condition = $condition)
+}
+
 function meta::pure::dsl::dataframe::fullJoin(left: DataSource[1], right: DataSource[1], condition: FilterCondition[1]): JoinOperation[1]
+{
+   ^JoinOperation(left = $left, right = $right, joinType = JoinType.FULL_OUTER, condition = $condition)
+}
+
+function meta::pure::dsl::dataframe::fullJoin<T, V>(left: DataSource[1], right: DataSource[1], condition: Function<{T[1], V[1]->Boolean[1]}>[1]): JoinOperation[1]
 {
    ^JoinOperation(left = $left, right = $right, joinType = JoinType.FULL_OUTER, condition = $condition)
 }
@@ -640,9 +658,19 @@ function meta::pure::dsl::dataframe::count(expr: Expression[1]): CountFunction[1
    ^CountFunction(functionName = 'count', parameters = [$expr], distinct = false)
 }
 
+function meta::pure::dsl::dataframe::count<T>(col: ColSpec<T>[1]): CountFunction[1]
+{
+   ^CountFunction(functionName = 'count', parameters = [$col], distinct = false)
+}
+
 function meta::pure::dsl::dataframe::countDistinct(expr: Expression[1]): CountFunction[1]
 {
    ^CountFunction(functionName = 'count', parameters = [$expr], distinct = true)
+}
+
+function meta::pure::dsl::dataframe::countDistinct<T>(col: ColSpec<T>[1]): CountFunction[1]
+{
+   ^CountFunction(functionName = 'count', parameters = [$col], distinct = true)
 }
 
 // Type-safe aggregate functions
@@ -697,9 +725,19 @@ function meta::pure::dsl::dataframe::sum(expr: Expression[1]): SumFunction[1]
    ^SumFunction(functionName = 'sum', parameters = [$expr])
 }
 
+function meta::pure::dsl::dataframe::sum<T>(col: ColSpec<T>[1]): SumFunction[1]
+{
+   ^SumFunction(functionName = 'sum', parameters = [$col])
+}
+
 function meta::pure::dsl::dataframe::avg(expr: Expression[1]): AvgFunction[1]
 {
    ^AvgFunction(functionName = 'avg', parameters = [$expr])
+}
+
+function meta::pure::dsl::dataframe::avg<T>(col: ColSpec<T>[1]): AvgFunction[1]
+{
+   ^AvgFunction(functionName = 'avg', parameters = [$col])
 }
 
 function meta::pure::dsl::dataframe::min(expr: Expression[1]): MinFunction[1]
@@ -707,9 +745,19 @@ function meta::pure::dsl::dataframe::min(expr: Expression[1]): MinFunction[1]
    ^MinFunction(functionName = 'min', parameters = [$expr])
 }
 
+function meta::pure::dsl::dataframe::min<T>(col: ColSpec<T>[1]): MinFunction[1]
+{
+   ^MinFunction(functionName = 'min', parameters = [$col])
+}
+
 function meta::pure::dsl::dataframe::max(expr: Expression[1]): MaxFunction[1]
 {
    ^MaxFunction(functionName = 'max', parameters = [$expr])
+}
+
+function meta::pure::dsl::dataframe::max<T>(col: ColSpec<T>[1]): MaxFunction[1]
+{
+   ^MaxFunction(functionName = 'max', parameters = [$col])
 }
 
 // Helper functions for creating order by clauses
@@ -780,12 +828,12 @@ function meta::pure::dsl::dataframe::over(expr: Expression[1], window: Window[1]
 // OrderBy helper functions
 function meta::pure::dsl::dataframe::asc<T>(col: ColSpec<T>[1]): OrderByClause[1]
 {
-   ^OrderByClause(expression = col($col.name), direction = SortDirection.ASC);
+   ^OrderByClause(expression = ^ColumnReference(colSpec = ^ColSpec<Any>(name = $col.name)), direction = SortDirection.ASC);
 }
 
 function meta::pure::dsl::dataframe::desc<T>(col: ColSpec<T>[1]): OrderByClause[1]
 {
-   ^OrderByClause(expression = col($col.name), direction = SortDirection.DESC);
+   ^OrderByClause(expression = ^ColumnReference(colSpec = ^ColSpec<Any>(name = $col.name)), direction = SortDirection.DESC);
 }
 
 function meta::pure::dsl::dataframe::getFunctionName(expr: Expression[1]): String[1]
@@ -810,7 +858,7 @@ function
    meta::pure::dsl::dataframe::over<T>(cols: ColSpec<(?:?)⊆T>[1]): Window[1]
 {
    ^Window(
-      partitionBy = [col($cols.name)]
+      partitionBy = [~$cols.name]
    );
 }
 
@@ -820,7 +868,7 @@ function
    meta::pure::dsl::dataframe::over<T>(cols: ColSpecArray<(?:?)⊆T>[1]): Window[1]
 {
    ^Window(
-      partitionBy = $cols.names->map(c | col($c))
+      partitionBy = $cols.names->map(c | ~$c)
    );
 }
 
@@ -850,7 +898,7 @@ function
    meta::pure::dsl::dataframe::over<T>(cols: ColSpec<(?:?)⊆T>[1], orderBy: OrderByClause[*]): Window[1]
 {
    ^Window(
-      partitionBy = [col($cols.name)],
+      partitionBy = [~$cols.name],
       orderBy = $orderBy
    );
 }
@@ -861,7 +909,7 @@ function
    meta::pure::dsl::dataframe::over<T>(cols: ColSpecArray<(?:?)⊆T>[1], orderBy: OrderByClause[*]): Window[1]
 {
    ^Window(
-      partitionBy = $cols.names->map(c | col($c)),
+      partitionBy = $cols.names->map(c | ~$c),
       orderBy = $orderBy
    );
 }
@@ -872,7 +920,7 @@ function
    meta::pure::dsl::dataframe::over<T>(cols: ColSpec<(?:?)⊆T>[1], frame: Frame[1]): Window[1]
 {
    ^Window(
-      partitionBy = [col($cols.name)],
+      partitionBy = [~$cols.name],
       frame = $frame
    );
 }
@@ -880,6 +928,11 @@ function
 function meta::pure::dsl::dataframe::partitionBy(columns: Expression[*]): Window[1]
 {
    ^Window(partitionBy = $columns, orderBy = []);
+}
+
+function meta::pure::dsl::dataframe::partitionBy<T>(columns: ColSpec<T>[*]): Window[1]
+{
+   ^Window(partitionBy = $columns->map(c | ~$c.name), orderBy = []);
 }
 
 function meta::pure::dsl::dataframe::orderBy(window: Window[1], clauses: OrderByClause[*]): Window[1]
@@ -1020,9 +1073,19 @@ function meta::pure::dsl::dataframe::sum(expr: Expression[1]): FunctionExpressio
    ^FunctionExpression(functionName = 'sum', parameters = [$expr]);
 }
 
+function meta::pure::dsl::dataframe::sum<T>(col: ColSpec<T>[1]): FunctionExpression[1]
+{
+   ^FunctionExpression(functionName = 'sum', parameters = [$col]);
+}
+
 function meta::pure::dsl::dataframe::avg(expr: Expression[1]): FunctionExpression[1]
 {
    ^FunctionExpression(functionName = 'avg', parameters = [$expr]);
+}
+
+function meta::pure::dsl::dataframe::avg<T>(col: ColSpec<T>[1]): FunctionExpression[1]
+{
+   ^FunctionExpression(functionName = 'avg', parameters = [$col]);
 }
 
 function meta::pure::dsl::dataframe::min(expr: Expression[1]): FunctionExpression[1]
@@ -1030,14 +1093,29 @@ function meta::pure::dsl::dataframe::min(expr: Expression[1]): FunctionExpressio
    ^FunctionExpression(functionName = 'min', parameters = [$expr]);
 }
 
+function meta::pure::dsl::dataframe::min<T>(col: ColSpec<T>[1]): FunctionExpression[1]
+{
+   ^FunctionExpression(functionName = 'min', parameters = [$col]);
+}
+
 function meta::pure::dsl::dataframe::max(expr: Expression[1]): FunctionExpression[1]
 {
    ^FunctionExpression(functionName = 'max', parameters = [$expr]);
 }
 
+function meta::pure::dsl::dataframe::max<T>(col: ColSpec<T>[1]): FunctionExpression[1]
+{
+   ^FunctionExpression(functionName = 'max', parameters = [$col]);
+}
+
 function meta::pure::dsl::dataframe::count(expr: Expression[1]): FunctionExpression[1]
 {
    ^FunctionExpression(functionName = 'count', parameters = [$expr]);
+}
+
+function meta::pure::dsl::dataframe::count<T>(col: ColSpec<T>[1]): FunctionExpression[1]
+{
+   ^FunctionExpression(functionName = 'count', parameters = [$col]);
 }
 
 // WITH clause helper functions
@@ -1084,7 +1162,7 @@ function meta::pure::dsl::dataframe::fromTDS<T>(tds: TDS<T>[1]): DataFrame[1]
    
    // Create columns from TDS
    let columns = $columnNames->map(name | 
-      ^Column(name = $name, expression = ^ColumnReference(columnName = $name), alias = $name)
+      ^Column(name = $name, expression = ^ColumnReference(colSpec = ^ColSpec<Any>(name = $name)), alias = $name)
    );
    
    // Create DataFrame from TDS
@@ -1105,7 +1183,7 @@ function meta::pure::dsl::dataframe::parseTDSLiteral(tdsText: String[1]): DataFr
    
    // Create columns
    let columns = $columnNames->map(name | 
-      ^Column(name = $name, expression = ^ColumnReference(columnName = $name), alias = $name)
+      ^Column(name = $name, expression = ^ColumnReference(colSpec = ^ColSpec<Any>(name = $name)), alias = $name)
    );
    
    // Create DataFrame

--- a/src/main/resources/pure/dsl/dataframe/dataframe.pure
+++ b/src/main/resources/pure/dsl/dataframe/dataframe.pure
@@ -828,12 +828,12 @@ function meta::pure::dsl::dataframe::over(expr: Expression[1], window: Window[1]
 // OrderBy helper functions
 function meta::pure::dsl::dataframe::asc<T>(col: ColSpec<T>[1]): OrderByClause[1]
 {
-   ^OrderByClause(expression = ^ColumnReference(colSpec = ^ColSpec<Any>(name = $col.name)), direction = SortDirection.ASC);
+   ^OrderByClause(expression = ^ColumnReference(colSpec = $col), direction = SortDirection.ASC);
 }
 
 function meta::pure::dsl::dataframe::desc<T>(col: ColSpec<T>[1]): OrderByClause[1]
 {
-   ^OrderByClause(expression = ^ColumnReference(colSpec = ^ColSpec<Any>(name = $col.name)), direction = SortDirection.DESC);
+   ^OrderByClause(expression = ^ColumnReference(colSpec = $col), direction = SortDirection.DESC);
 }
 
 function meta::pure::dsl::dataframe::getFunctionName(expr: Expression[1]): String[1]
@@ -932,7 +932,7 @@ function meta::pure::dsl::dataframe::partitionBy(columns: Expression[*]): Window
 
 function meta::pure::dsl::dataframe::partitionBy<T>(columns: ColSpec<T>[*]): Window[1]
 {
-   ^Window(partitionBy = $columns->map(c | ~$c.name), orderBy = []);
+   ^Window(partitionBy = $columns->map(c | ^ColumnReference(colSpec = $c)), orderBy = []);
 }
 
 function meta::pure::dsl::dataframe::orderBy(window: Window[1], clauses: OrderByClause[*]): Window[1]
@@ -1162,7 +1162,7 @@ function meta::pure::dsl::dataframe::fromTDS<T>(tds: TDS<T>[1]): DataFrame[1]
    
    // Create columns from TDS
    let columns = $columnNames->map(name | 
-      ^Column(name = $name, expression = ^ColumnReference(colSpec = ^ColSpec<Any>(name = $name)), alias = $name)
+      ^Column(name = $name, expression = ^ColumnReference(colSpec = ^ColSpec<T>(name = $name)), alias = $name)
    );
    
    // Create DataFrame from TDS
@@ -1183,7 +1183,7 @@ function meta::pure::dsl::dataframe::parseTDSLiteral(tdsText: String[1]): DataFr
    
    // Create columns
    let columns = $columnNames->map(name | 
-      ^Column(name = $name, expression = ^ColumnReference(colSpec = ^ColSpec<Any>(name = $name)), alias = $name)
+      ^Column(name = $name, expression = ^ColumnReference(colSpec = ^ColSpec<T>(name = $name)), alias = $name)
    );
    
    // Create DataFrame

--- a/src/main/resources/pure/dsl/dataframe/inlineTDS.pure
+++ b/src/main/resources/pure/dsl/dataframe/inlineTDS.pure
@@ -31,7 +31,7 @@ Class <<access.private>> meta::pure::dsl::dataframe::metamodel::TableReference
 // Function to create an inline TDS DataFrame
 function meta::pure::dsl::dataframe::inlineTDS(columns: String[*], rows: Any[*][*]): DataFrame[1]
 {
-   let columnDefs = $columns->map(c | ^Column(name = $c, expression = ^ColumnReference(columnName = $c)));
+   let columnDefs = $columns->map(c | ^Column(name = $c, expression = ^ColumnReference(colSpec = ^ColSpec<Any>(name = $c))));
    
    let source = ^TableReference(
       tableName = 'inline_tds',

--- a/src/main/resources/pure/dsl/duckdb/duckdb.pure
+++ b/src/main/resources/pure/dsl/duckdb/duckdb.pure
@@ -192,7 +192,7 @@ function <<access.private>> meta::pure::dsl::duckdb::generateDuckDBExpression(ex
 {
    $expr->match([
       l: LiteralExpression[1] | $l.value->generateDuckDBLiteral(),
-      c: ColumnReference[1] | if($c.tableAlias->isNotEmpty(), $c.tableAlias->toOne() + '.', '') + $c.columnName,
+      c: ColumnReference[1] | if($c.tableAlias->isNotEmpty(), $c.tableAlias->toOne() + '.', '') + $c.colSpec.name,
       f: FunctionExpression[1] | $f->generateDuckDBFunction(),
       b: BinaryOperation[1] | '(' + $b.left->generateDuckDBExpression() + ' ' + $b.operator->generateDuckDBBinaryOperator() + ' ' + $b.right->generateDuckDBExpression() + ')',
       u: UnaryOperation[1] | $u.operator->generateDuckDBUnaryOperator() + '(' + $u.expression->generateDuckDBExpression() + ')',

--- a/src/main/resources/pure/dsl/examples/bigquery_features.pure
+++ b/src/main/resources/pure/dsl/examples/bigquery_features.pure
@@ -49,8 +49,8 @@ function <<functionType.Example>> meta::pure::dsl::examples::bigquery::exceptRep
    
    // Example of SELECT * REPLACE
    let replacements = newMap([
-      pair('salary', ^FunctionExpression(functionName = 'FORMAT', parameters = [col('salary'), literal('$%.2f')])),
-      pair('hire_date', ^FunctionExpression(functionName = 'FORMAT_DATE', parameters = [literal('%Y-%m-%d'), col('hire_date')]))
+      pair('salary', ^FunctionExpression(functionName = 'FORMAT', parameters = [~salary, literal('$%.2f')])),
+      pair('hire_date', ^FunctionExpression(functionName = 'FORMAT_DATE', parameters = [literal('%Y-%m-%d'), ~hire_date]))
    ]);
    
    let replaceExample = table('employees')

--- a/src/main/resources/pure/dsl/snowflake/snowflake.pure
+++ b/src/main/resources/pure/dsl/snowflake/snowflake.pure
@@ -265,7 +265,7 @@ function <<access.private>> meta::pure::dsl::snowflake::generateSnowflakeExpress
 {
    $expr->match([
       l: LiteralExpression[1] | $l.value->generateSnowflakeLiteral(),
-      c: ColumnReference[1] | if($c.tableAlias->isNotEmpty(), $c.tableAlias->toOne() + '.', '') + $c.columnName,
+      c: ColumnReference[1] | if($c.tableAlias->isNotEmpty(), $c.tableAlias->toOne() + '.', '') + $c.colSpec.name,
       f: FunctionExpression[1] | $f->generateSnowflakeFunction(),
       b: BinaryOperation[1] | '(' + $b.left->generateSnowflakeExpression() + ' ' + $b.operator->generateSnowflakeBinaryOperator() + ' ' + $b.right->generateSnowflakeExpression() + ')',
       u: UnaryOperation[1] | $u.operator->generateSnowflakeUnaryOperator() + '(' + $u.expression->generateSnowflakeExpression() + ')',

--- a/src/test/resources/pure/dsl/tests/bigquery_features_tests.pure
+++ b/src/test/resources/pure/dsl/tests/bigquery_features_tests.pure
@@ -53,7 +53,7 @@ function <<test.Test>> meta::pure::dsl::tests::testBigQueryExceptReplace(): Bool
    // Test SELECT * REPLACE
    let replacements = newMap([
       pair('salary', literal(0)),
-      pair('age', ^FunctionExpression(functionName = 'CAST', parameters = [col('age'), literal('INT64')]))
+      pair('age', ^FunctionExpression(functionName = 'CAST', parameters = [~age, literal('INT64')]))
    ]);
    let dfReplace = table('employees')->replace($replacements);
    let sqlReplace = $dfReplace->generateBigQuerySQL();

--- a/src/test/resources/pure/dsl/tests/bigquery_qualify_tests.pure
+++ b/src/test/resources/pure/dsl/tests/bigquery_qualify_tests.pure
@@ -19,12 +19,12 @@ import meta::pure::dsl::bigquery::*;
 function <<meta::pure::profiles::test.Test>> {meta.pure.profiles.test.AlloyOnly} meta::pure::dsl::tests::testBigQueryQualify(): Boolean[1]
 {
    // Create a SELECT query with a QUALIFY clause
-   let windowFunc = rank()->over(partitionBy([col('department')]), [asc(col('salary'))]);
+   let windowFunc = rank()->over(partitionBy([~department]), [asc(~salary)]);
    let df = select([
-      as(col('id'), 'id'),
-      as(col('name'), 'name'),
-      as(col('department'), 'department'),
-      as(col('salary'), 'salary')
+      as(~id, 'id'),
+      as(~name, 'name'),
+      as(~department, 'department'),
+      as(~salary, 'salary')
    ])
    ->from(table('employees'))
    ->qualify({x | $windowFunc < 3});

--- a/src/test/resources/pure/dsl/tests/databricks_tests.pure
+++ b/src/test/resources/pure/dsl/tests/databricks_tests.pure
@@ -19,12 +19,12 @@ import meta::pure::dsl::databricks::*;
 function <<meta::pure::profiles::test.Test>> {meta.pure.profiles.test.AlloyOnly} meta::pure::dsl::tests::testDatabricksQualify(): Boolean[1]
 {
    // Create a SELECT query with a QUALIFY clause
-   let windowFunc = rank()->over(partitionBy([col('department')]), [asc(col('salary'))]);
+   let windowFunc = rank()->over(partitionBy([~department]), [asc(~salary)]);
    let df = select([
-      as(col('id'), 'id'),
-      as(col('name'), 'name'),
-      as(col('department'), 'department'),
-      as(col('salary'), 'salary')
+      as(~id, 'id'),
+      as(~name, 'name'),
+      as(~department, 'department'),
+      as(~salary, 'salary')
    ])
    ->from(table('employees'))
    ->qualify({x | $windowFunc < 3});

--- a/src/test/resources/pure/dsl/tests/dataframe_tests.pure
+++ b/src/test/resources/pure/dsl/tests/dataframe_tests.pure
@@ -28,8 +28,8 @@ function <<test.Test>> meta::pure::dsl::tests::testSimpleSelect(): Boolean[1]
 {
    // Create a simple SELECT query
    let df = select([
-      as(col('id'), 'id'),
-      as(col('name'), 'name')
+      as(~id, 'id'),
+      as(~name, 'name')
    ])->from(table('customers'));
    
    // Generate SQL for Snowflake
@@ -47,8 +47,8 @@ function <<test.Test>> meta::pure::dsl::tests::testSelectWithFilter(): Boolean[1
 {
    // Create a SELECT query with filter using Pure built-ins
    let df = select([
-      as(col('id'), 'id'),
-      as(col('name'), 'name')
+      as(~id, 'id'),
+      as(~name, 'name')
    ])->from(table('customers'))->filter({x | $x.id == 100});
    
    // Generate SQL for Snowflake
@@ -66,9 +66,9 @@ function <<test.Test>> meta::pure::dsl::tests::testSelectWithJoin(): Boolean[1]
 {
    // Create a SELECT query with JOIN
    let df = select([
-      as(col('c', 'id'), 'customer_id'),
-      as(col('c', 'name'), 'customer_name'),
-      as(col('o', 'id'), 'order_id')
+      as(~('c', 'id'), 'customer_id'),
+      as(~('c', 'name'), 'customer_name'),
+      as(~('o', 'id'), 'order_id')
    ])->from(
       join(
          tableAs('customers', 'c'),
@@ -92,10 +92,10 @@ function <<test.Test>> meta::pure::dsl::tests::testSelectWithGroupBy(): Boolean[
 {
    // Create a SELECT query with GROUP BY and aggregate functions
    let df = select([
-      as(col('category'), 'category'),
-      as(count(col('id')), 'count'),
-      as(sum(col('amount')), 'total_amount')
-   ])->from(table('orders'))->groupBy([col('category')]);
+      as(~category, 'category'),
+      as(count(~id), 'count'),
+      as(sum(~amount), 'total_amount')
+   ])->from(table('orders'))->groupBy([~category]);
    
    // Generate SQL for Snowflake
    let snowflakeSQL = $df->generateSnowflakeSQL();
@@ -112,9 +112,9 @@ function <<test.Test>> meta::pure::dsl::tests::testSelectWithOrderBy(): Boolean[
 {
    // Create a SELECT query with ORDER BY
    let df = select([
-      as(col('id'), 'id'),
-      as(col('name'), 'name')
-   ])->from(table('customers'))->orderBy([asc(col('name')), desc(col('id'))]);
+      as(~id, 'id'),
+      as(~name, 'name')
+   ])->from(table('customers'))->orderBy([asc(~name), desc(~id)]);
    
    // Generate SQL for Snowflake
    let snowflakeSQL = $df->generateSnowflakeSQL();
@@ -131,8 +131,8 @@ function <<test.Test>> meta::pure::dsl::tests::testSelectWithLimit(): Boolean[1]
 {
    // Create a SELECT query with LIMIT and OFFSET
    let df = select([
-      as(col('id'), 'id'),
-      as(col('name'), 'name')
+      as(~id, 'id'),
+      as(~name, 'name')
    ])->from(table('customers'))->limit(10)->offset(20);
    
    // Generate SQL for Snowflake
@@ -150,9 +150,9 @@ function <<test.Test>> meta::pure::dsl::tests::testComplexQuery(): Boolean[1]
 {
    // Create a complex SELECT query with multiple features
    let df = selectDistinct([
-      as(col('c', 'category'), 'category'),
-      as(count(col('o', 'id')), 'order_count'),
-      as(sum(col('o', 'amount')), 'total_amount')
+      as(~('c', 'category'), 'category'),
+      as(count(~('o', 'id')), 'order_count'),
+      as(sum(~('o', 'amount')), 'total_amount')
    ])->from(
       leftJoin(
          tableAs('categories', 'c'),
@@ -160,9 +160,9 @@ function <<test.Test>> meta::pure::dsl::tests::testComplexQuery(): Boolean[1]
          {c, o | $c.id == $o.category_id}
       )
    )->filter({x | $x.o.amount > 100 && $x.o.customer_id != null})->groupBy([
-      col('c', 'category')
-   ])->having({x | count(col('o', 'id')) > 5})->orderBy([
-      desc(sum(col('o', 'amount')))
+      ~('c', 'category')
+   ])->having({x | count(~('o', 'id')) > 5})->orderBy([
+      desc(sum(~('o', 'amount')))
    ])->limit(5);
    
    // Generate SQL for Snowflake
@@ -195,8 +195,8 @@ function <<test.Test>> meta::pure::dsl::tests::testDatabaseSpecificSyntaxDiffere
    // Test a case where Snowflake and DuckDB have different syntax
    // In this case, LEFT OUTER JOIN vs LEFT JOIN
    let df = select([
-      as(col('c', 'name'), 'customer_name'),
-      as(col('o', 'id'), 'order_id')
+      as(~('c', 'name'), 'customer_name'),
+      as(~('o', 'id'), 'order_id')
    ])->from(
       leftJoin(
          tableAs('customers', 'c'),
@@ -222,9 +222,9 @@ function <<test.Test>> meta::pure::dsl::tests::testWindowFunctionsBasic(): Boole
 {
    // Create a SELECT query with basic window functions
    let df = select([
-      as(col('id'), 'id'),
-      as(col('name'), 'name'),
-      as(over(rowNumber(), partitionBy([col('category')])->orderBy([asc(col('id'))])), 'row_num')
+      as(~id, 'id'),
+      as(~name, 'name'),
+      as(over(rowNumber(), partitionBy([~category])->orderBy([asc(~id)])), 'row_num')
    ])->from(table('employees'));
    
    // Generate SQL for Snowflake
@@ -242,13 +242,13 @@ function <<test.Test>> meta::pure::dsl::tests::testWindowFunctionsWithFrames(): 
 {
    // Create a SELECT query with window functions that use frames
    let df = select([
-      as(col('id'), 'id'),
-      as(col('sales'), 'sales'),
-      as(over(sum(col('sales')), partitionBy([col('region')])
-                               ->orderBy([asc(col('date'))])
+      as(~id, 'id'),
+      as(~sales, 'sales'),
+      as(over(sum(~sales), partitionBy([~region])
+                               ->orderBy([asc(~date)])
                                ->rowsBetween(unboundedPreceding(), currentRow())), 'running_total'),
-      as(over(avg(col('sales')), partitionBy([col('region')])
-                               ->orderBy([asc(col('date'))])
+      as(over(avg(~sales), partitionBy([~region])
+                               ->orderBy([asc(~date)])
                                ->rowsBetween(preceding(2), following(2))), 'moving_avg')
    ])->from(table('sales'));
    
@@ -267,11 +267,11 @@ function <<test.Test>> meta::pure::dsl::tests::testWindowFunctionsWithRange(): B
 {
    // Create a SELECT query with window functions that use RANGE frame type
    let df = select([
-      as(col('id'), 'id'),
-      as(col('date'), 'date'),
-      as(col('sales'), 'sales'),
-      as(over(sum(col('sales')), partitionBy([col('region')])
-                               ->orderBy([asc(col('date'))])
+      as(~id, 'id'),
+      as(~date, 'date'),
+      as(~sales, 'sales'),
+      as(over(sum(~sales), partitionBy([~region])
+                               ->orderBy([asc(~date)])
                                ->rangeBetween(unboundedPreceding(), currentRow())), 'running_total')
    ])->from(table('sales'));
    
@@ -290,13 +290,13 @@ function <<test.Test>> meta::pure::dsl::tests::testLeadLagWindowFunctions(): Boo
 {
    // Create a SELECT query with LEAD and LAG window functions
    let df = select([
-      as(col('id'), 'id'),
-      as(col('date'), 'date'),
-      as(col('sales'), 'sales'),
-      as(over(lead(col('sales')), partitionBy([col('region')])->orderBy([asc(col('date'))])), 'next_day_sales'),
-      as(over(lead(col('sales'), 2, literal(0)), partitionBy([col('region')])->orderBy([asc(col('date'))])), 'sales_in_two_days'),
-      as(over(lag(col('sales')), partitionBy([col('region')])->orderBy([asc(col('date'))])), 'prev_day_sales'),
-      as(over(lag(col('sales'), 3, literal(0)), partitionBy([col('region')])->orderBy([asc(col('date'))])), 'sales_three_days_ago')
+      as(~id, 'id'),
+      as(~date, 'date'),
+      as(~sales, 'sales'),
+      as(over(lead(~sales), partitionBy([~region])->orderBy([asc(~date)])), 'next_day_sales'),
+      as(over(lead(~sales, 2, literal(0)), partitionBy([~region])->orderBy([asc(~date)])), 'sales_in_two_days'),
+      as(over(lag(~sales), partitionBy([~region])->orderBy([asc(~date)])), 'prev_day_sales'),
+      as(over(lag(~sales, 3, literal(0)), partitionBy([~region])->orderBy([asc(~date)])), 'sales_three_days_ago')
    ])->from(table('sales'));
    
    // Generate SQL for Snowflake
@@ -314,12 +314,12 @@ function <<test.Test>> meta::pure::dsl::tests::testRankingWindowFunctions(): Boo
 {
    // Create a SELECT query with ranking window functions
    let df = select([
-      as(col('id'), 'id'),
-      as(col('name'), 'name'),
-      as(col('score'), 'score'),
-      as(over(rank(), partitionBy([col('department')])->orderBy([desc(col('score'))])), 'rank'),
-      as(over(denseRank(), partitionBy([col('department')])->orderBy([desc(col('score'))])), 'dense_rank'),
-      as(over(rowNumber(), partitionBy([col('department')])->orderBy([desc(col('score'))])), 'row_number')
+      as(~id, 'id'),
+      as(~name, 'name'),
+      as(~score, 'score'),
+      as(over(rank(), partitionBy([~department])->orderBy([desc(~score)])), 'rank'),
+      as(over(denseRank(), partitionBy([~department])->orderBy([desc(~score)])), 'dense_rank'),
+      as(over(rowNumber(), partitionBy([~department])->orderBy([desc(~score)])), 'row_number')
    ])->from(table('employees'));
    
    // Generate SQL for Snowflake
@@ -337,14 +337,14 @@ function <<test.Test>> meta::pure::dsl::tests::testFirstLastValueWindowFunctions
 {
    // Create a SELECT query with FIRST_VALUE and LAST_VALUE window functions
    let df = select([
-      as(col('id'), 'id'),
-      as(col('date'), 'date'),
-      as(col('sales'), 'sales'),
-      as(over(firstValue(col('sales')), partitionBy([col('region')])
-                                  ->orderBy([asc(col('date'))])
+      as(~id, 'id'),
+      as(~date, 'date'),
+      as(~sales, 'sales'),
+      as(over(firstValue(~sales), partitionBy([~region])
+                                  ->orderBy([asc(~date)])
                                   ->rowsBetween(unboundedPreceding(), unboundedFollowing())), 'first_sale'),
-      as(over(lastValue(col('sales')), partitionBy([col('region')])
-                                 ->orderBy([asc(col('date'))])
+      as(over(lastValue(~sales), partitionBy([~region])
+                                 ->orderBy([asc(~date)])
                                  ->rowsBetween(unboundedPreceding(), unboundedFollowing())), 'last_sale')
    ])->from(table('sales'));
    
@@ -363,14 +363,14 @@ function <<test.Test>> meta::pure::dsl::tests::testAggregateWindowFunctions(): B
 {
    // Create a SELECT query with aggregate window functions
    let df = select([
-      as(col('id'), 'id'),
-      as(col('department'), 'department'),
-      as(col('salary'), 'salary'),
-      as(over(sum(col('salary')), partitionBy([col('department')])), 'dept_total'),
-      as(over(avg(col('salary')), partitionBy([col('department')])), 'dept_avg'),
-      as(over(min(col('salary')), partitionBy([col('department')])), 'dept_min'),
-      as(over(max(col('salary')), partitionBy([col('department')])), 'dept_max'),
-      as(over(count(col('id')), partitionBy([col('department')])), 'dept_count')
+      as(~id, 'id'),
+      as(~department, 'department'),
+      as(~salary, 'salary'),
+      as(over(sum(~salary), partitionBy([~department])), 'dept_total'),
+      as(over(avg(~salary), partitionBy([~department])), 'dept_avg'),
+      as(over(min(~salary), partitionBy([~department])), 'dept_min'),
+      as(over(max(~salary), partitionBy([~department])), 'dept_max'),
+      as(over(count(~id), partitionBy([~department])), 'dept_count')
    ])->from(table('employees'));
    
    // Generate SQL for Snowflake
@@ -403,8 +403,8 @@ function <<test.Test>> meta::pure::dsl::tests::testCommonTableExpressions(): Boo
    // Create a CTE for customer data
    let customerCte = cte('customers',
       select([
-         as(col('id'), 'id'),
-         as(col('name'), 'name')
+         as(~id, 'id'),
+         as(~name, 'name')
       ])
       ->from(table('customer_data'))
    );
@@ -412,17 +412,17 @@ function <<test.Test>> meta::pure::dsl::tests::testCommonTableExpressions(): Boo
    // Create a CTE for order data
    let orderCte = cte('orders',
       select([
-         as(col('id'), 'id'),
-         as(col('customer_id'), 'customer_id'),
-         as(col('amount'), 'amount')
+         as(~id, 'id'),
+         as(~customer_id, 'customer_id'),
+         as(~amount, 'amount')
       ])
       ->from(table('order_data'))
    );
    
    // Create a main query using the CTEs
    let df = select([
-      as(col('c', 'name'), 'customer_name'),
-      as(sum(col('o', 'amount')), 'total_orders')
+      as(~('c', 'name'), 'customer_name'),
+      as(sum(~('o', 'amount')), 'total_orders')
    ])
    ->from(join(
       table('customers', 'c'),
@@ -430,7 +430,7 @@ function <<test.Test>> meta::pure::dsl::tests::testCommonTableExpressions(): Boo
       JoinType.INNER,
       {c, o | $c.id == $o.customer_id}
    ))
-   ->groupBy([col('c', 'name')])
+   ->groupBy([~('c', 'name')])
    ->with([$customerCte, $orderCte]);
    
    // Generate SQL for all database types
@@ -452,8 +452,8 @@ function <<test.Test>> meta::pure::dsl::tests::testDatabricksSQL(): Boolean[1]
 {
    // Create a simple DataFrame
    let df = select([
-      as(col('c', 'name'), 'customer_name'),
-      as(col('c', 'age'), 'customer_age')
+      as(~('c', 'name'), 'customer_name'),
+      as(~('c', 'age'), 'customer_age')
    ])->from(tableAs('customers', 'c'))->filter({x | $x.c.age > 30});
    
    // Generate Databricks SQL
@@ -475,10 +475,10 @@ function <<test.Test>> meta::pure::dsl::tests::testDatabricksQualify(): Boolean[
 {
    // Create a DataFrame with a window function and QUALIFY clause
    let df = select([
-      as(col('c', 'name'), 'customer_name'),
-      as(col('c', 'region'), 'region'),
-      as(col('c', 'sales'), 'sales'),
-      as(rowNumber()->over(partitionBy([col('c', 'region')]), orderBy([desc(col('c', 'sales'))])), 'sales_rank')
+      as(~('c', 'name'), 'customer_name'),
+      as(~('c', 'region'), 'region'),
+      as(~('c', 'sales'), 'sales'),
+      as(rowNumber()->over(partitionBy([~('c', 'region')]), orderBy([desc(~('c', 'sales'))])), 'sales_rank')
    ])
    ->from(tableAs('customers', 'c'))
    ->qualify({x | $x.sales_rank <= 3}); // Only keep top 3 customers by sales in each region
@@ -497,12 +497,12 @@ function <<test.Test>> meta::pure::dsl::tests::testDatabricksClusterBy(): Boolea
 {
    // Create a DataFrame with CLUSTER BY clause (Databricks-specific)
    let df = select([
-      as(col('c', 'name'), 'customer_name'),
-      as(col('c', 'region'), 'region'),
-      as(col('c', 'sales'), 'sales')
+      as(~('c', 'name'), 'customer_name'),
+      as(~('c', 'region'), 'region'),
+      as(~('c', 'sales'), 'sales')
    ])
    ->from(tableAs('customers', 'c'))
-   ->clusterBy([col('region')]); // Cluster results by region
+   ->clusterBy([~region]); // Cluster results by region
    
    // Generate Databricks SQL
    let databricksSQL = $df->generateDatabricksSQL();

--- a/src/test/resources/pure/dsl/tests/over_tests.pure
+++ b/src/test/resources/pure/dsl/tests/over_tests.pure
@@ -55,7 +55,7 @@ function <<test.Test>> meta::pure::dsl::tests::testNewOverFunction(): Boolean[1]
    let window5 = over([~department], [asc(~salary)], rows(unbounded(), 0));
    
    // Test SQL generation
-   let avgSalary = avg(col('salary'));
+   let avgSalary = avg(~salary);
    let rankExpr = rank();
    
    let dfWithWindow = $df
@@ -90,7 +90,7 @@ function <<test.Test>> meta::pure::dsl::tests::testFrameTypes(): Boolean[1]
    // Test with rows frame
    let window1 = over([asc(~id)], $rowsFrame);
    let dfWithRowsFrame = $df->extend([
-      sum(col('salary'))->over($window1)->as('running_sum')
+      sum(~salary)->over($window1)->as('running_sum')
    ]);
    
    let sql1 = $dfWithRowsFrame->generateDuckDBSQL();
@@ -99,7 +99,7 @@ function <<test.Test>> meta::pure::dsl::tests::testFrameTypes(): Boolean[1]
    // Test with range frame
    let window2 = over([asc(~id)], $rangeFrame);
    let dfWithRangeFrame = $df->extend([
-      avg(col('salary'))->over($window2)->as('moving_avg')
+      avg(~salary)->over($window2)->as('moving_avg')
    ]);
    
    let sql2 = $dfWithRangeFrame->generateDuckDBSQL();
@@ -136,9 +136,9 @@ function <<test.Test>> meta::pure::dsl::tests::testFrameValues(): Boolean[1]
    let window3 = over([asc(~id)], $frame3);
    
    let dfWithFrames = $df->extend([
-      sum(col('salary'))->over($window1)->as('sum1'),
-      sum(col('salary'))->over($window2)->as('sum2'),
-      sum(col('salary'))->over($window3)->as('sum3')
+      sum(~salary)->over($window1)->as('sum1'),
+      sum(~salary)->over($window2)->as('sum2'),
+      sum(~salary)->over($window3)->as('sum3')
    ]);
    
    let sql = $dfWithFrames->generateDuckDBSQL();
@@ -165,7 +165,7 @@ function <<test.Test>> meta::pure::dsl::tests::testSnowflakeWindowSQL(): Boolean
    
    let dfWithWindow = $df->extend([
       rank()->over($window)->as('rank'),
-      avg(col('salary'))->over($window)->as('avg_salary')
+      avg(~salary)->over($window)->as('avg_salary')
    ]);
    
    let sql = $dfWithWindow->generateSnowflakeSQL();

--- a/src/test/resources/pure/dsl/tests/postgres_tests.pure
+++ b/src/test/resources/pure/dsl/tests/postgres_tests.pure
@@ -25,8 +25,8 @@ function <<test.Test>> meta::pure::dsl::tests::testPostgresSimpleSelect(): Boole
 {
    // Create a simple SELECT query
    let df = select([
-      as(col('id'), 'id'),
-      as(col('name'), 'name')
+      as(~id, 'id'),
+      as(~name, 'name')
    ])->from(table('customers'));
    
    // Generate SQL for PostgreSQL
@@ -40,8 +40,8 @@ function <<test.Test>> meta::pure::dsl::tests::testPostgresSelectWithFilter(): B
 {
    // Create a SELECT query with filter using Pure built-ins
    let df = select([
-      as(col('id'), 'id'),
-      as(col('name'), 'name')
+      as(~id, 'id'),
+      as(~name, 'name')
    ])->from(table('customers'))->filter({x | $x.id == 100});
    
    // Generate SQL for PostgreSQL
@@ -55,9 +55,9 @@ function <<test.Test>> meta::pure::dsl::tests::testPostgresSelectWithJoin(): Boo
 {
    // Create a SELECT query with JOIN
    let df = select([
-      as(col('c', 'id'), 'customer_id'),
-      as(col('c', 'name'), 'customer_name'),
-      as(col('o', 'id'), 'order_id')
+      as(~('c', 'id'), 'customer_id'),
+      as(~('c', 'name'), 'customer_name'),
+      as(~('o', 'id'), 'order_id')
    ])->from(
       join(
          tableAs('customers', 'c'),
@@ -77,10 +77,10 @@ function <<test.Test>> meta::pure::dsl::tests::testPostgresSelectWithGroupBy(): 
 {
    // Create a SELECT query with GROUP BY and aggregate functions
    let df = select([
-      as(col('category'), 'category'),
-      as(count(col('id')), 'count'),
-      as(sum(col('amount')), 'total_amount')
-   ])->from(table('orders'))->groupBy([col('category')]);
+      as(~category, 'category'),
+      as(count(~id), 'count'),
+      as(sum(~amount), 'total_amount')
+   ])->from(table('orders'))->groupBy([~category]);
    
    // Generate SQL for PostgreSQL
    let postgresSQL = $df->generatePostgresSQL();
@@ -93,9 +93,9 @@ function <<test.Test>> meta::pure::dsl::tests::testPostgresSelectWithOrderBy(): 
 {
    // Create a SELECT query with ORDER BY
    let df = select([
-      as(col('id'), 'id'),
-      as(col('name'), 'name')
-   ])->from(table('customers'))->orderBy([asc(col('name')), desc(col('id'))]);
+      as(~id, 'id'),
+      as(~name, 'name')
+   ])->from(table('customers'))->orderBy([asc(~name), desc(~id)]);
    
    // Generate SQL for PostgreSQL
    let postgresSQL = $df->generatePostgresSQL();
@@ -108,8 +108,8 @@ function <<test.Test>> meta::pure::dsl::tests::testPostgresSelectWithLimit(): Bo
 {
    // Create a SELECT query with LIMIT and OFFSET
    let df = select([
-      as(col('id'), 'id'),
-      as(col('name'), 'name')
+      as(~id, 'id'),
+      as(~name, 'name')
    ])->from(table('customers'))->limit(10)->offset(20);
    
    // Generate SQL for PostgreSQL
@@ -123,9 +123,9 @@ function <<test.Test>> meta::pure::dsl::tests::testPostgresComplexQuery(): Boole
 {
    // Create a complex SELECT query with multiple features
    let df = selectDistinct([
-      as(col('c', 'category'), 'category'),
-      as(count(col('o', 'id')), 'order_count'),
-      as(sum(col('o', 'amount')), 'total_amount')
+      as(~('c', 'category'), 'category'),
+      as(count(~('o', 'id')), 'order_count'),
+      as(sum(~('o', 'amount')), 'total_amount')
    ])->from(
       leftJoin(
          tableAs('categories', 'c'),
@@ -133,9 +133,9 @@ function <<test.Test>> meta::pure::dsl::tests::testPostgresComplexQuery(): Boole
          {c, o | $c.id == $o.category_id}
       )
    )->filter({x | $x.o.amount > 100 && $x.o.customer_id != null})->groupBy([
-      col('c', 'category')
-   ])->having({x | count(col('o', 'id')) > 5})->orderBy([
-      desc(sum(col('o', 'amount')))
+      ~('c', 'category')
+   ])->having({x | count(~('o', 'id')) > 5})->orderBy([
+      desc(sum(~('o', 'amount')))
    ])->limit(5);
    
    // Generate SQL for PostgreSQL
@@ -156,12 +156,12 @@ function <<test.Test>> meta::pure::dsl::tests::testPostgresLateralJoin(): Boolea
 {
    // Test PostgreSQL LATERAL JOIN which has specific syntax
    let df = select([
-      as(col('c', 'id'), 'customer_id'),
-      as(col('o', 'value'), 'order_value')
+      as(~('c', 'id'), 'customer_id'),
+      as(~('o', 'value'), 'order_value')
    ])->from(
       lateralJoin(
          tableAs('customers', 'c'),
-         select([as(col('value'), 'value')])->from(table('orders')),
+         select([as(~value, 'value')])->from(table('orders')),
          'o',
          {c, o | $c.id == $o.customer_id}
       )
@@ -179,8 +179,8 @@ function <<test.Test>> meta::pure::dsl::tests::testPostgresWithCTE(): Boolean[1]
    // Create a CTE for customer data
    let customerCte = cte('customers',
       select([
-         as(col('id'), 'id'),
-         as(col('name'), 'name')
+         as(~id, 'id'),
+         as(~name, 'name')
       ])
       ->from(table('customer_data'))
    );
@@ -188,24 +188,24 @@ function <<test.Test>> meta::pure::dsl::tests::testPostgresWithCTE(): Boolean[1]
    // Create a CTE for order data
    let orderCte = cte('orders',
       select([
-         as(col('id'), 'id'),
-         as(col('customer_id'), 'customer_id'),
-         as(col('amount'), 'amount')
+         as(~id, 'id'),
+         as(~customer_id, 'customer_id'),
+         as(~amount, 'amount')
       ])
       ->from(table('order_data'))
    );
    
    // Create a main query using the CTEs
    let df = select([
-      as(col('c', 'name'), 'customer_name'),
-      as(sum(col('o', 'amount')), 'total_orders')
+      as(~('c', 'name'), 'customer_name'),
+      as(sum(~('o', 'amount')), 'total_orders')
    ])
    ->from(join(
       tableAs('customers', 'c'),
       tableAs('orders', 'o'),
       {c, o | $c.id == $o.customer_id}
    ))
-   ->groupBy([col('c', 'name')])
+   ->groupBy([~('c', 'name')])
    ->with([$customerCte, $orderCte]);
    
    // Generate SQL for PostgreSQL
@@ -221,8 +221,8 @@ function <<test.Test>> meta::pure::dsl::tests::testToSQLWithPostgres(): Boolean[
 {
    // Create a simple SELECT query
    let df = select([
-      as(col('id'), 'id'),
-      as(col('name'), 'name')
+      as(~id, 'id'),
+      as(~name, 'name')
    ])->from(table('customers'));
    
    // Test toSQL function with PostgreSQL database

--- a/src/test/resources/pure/dsl/tests/redshift_tests.pure
+++ b/src/test/resources/pure/dsl/tests/redshift_tests.pure
@@ -22,8 +22,8 @@ function <<meta::pure::profiles::test.Test>> {meta.pure.profiles.test.AlloyOnly}
             ->filter({x | $x.salary > 50000})
             ->select({x | [~name, ~department, ~salary]})
             ->groupBy([~department])
-            ->having({x | sum(col('salary')) > 100000})
-            ->orderBy([desc(col('department'))]);
+            ->having({x | sum(~salary) > 100000})
+            ->orderBy([desc(~department)]);
             
    let sql = $df->toSQL(Database.REDSHIFT);
    
@@ -35,8 +35,8 @@ function <<test.Test>> meta::pure::dsl::tests::testToSQLWithRedshift(): Boolean[
 {
    // Create a simple SELECT query
    let df = select([
-      as(col('id'), 'id'),
-      as(col('name'), 'name')
+      as(~id, 'id'),
+      as(~name, 'name')
    ])->from(table('customers'));
    
    // Test toSQL function with Redshift database

--- a/src/test/resources/pure/dsl/tests/scalar_function_tests.pure
+++ b/src/test/resources/pure/dsl/tests/scalar_function_tests.pure
@@ -31,8 +31,8 @@ function <<test.Test>> meta::pure::dsl::tests::testCommonMathFunctions(): Boolea
 {
    // Create a DataFrame with math functions
    let df = select([
-      abs(col('value'))->as('abs_value'),
-      cos(col('angle'))->as('cos_angle')
+      abs(~value)->as('abs_value'),
+      cos(~angle)->as('cos_angle')
    ])
    ->from(table('data'));
    
@@ -70,7 +70,7 @@ function <<test.Test>> meta::pure::dsl::tests::testDateFunctionsWithVaryingSynta
 {
    // Create a DataFrame with date functions
    let df = select([
-      datediff(literal('day'), col('start_date'), col('end_date'))->as('days_diff')
+      datediff(literal('day'), ~start_date, ~end_date)->as('days_diff')
    ])
    ->from(table('date_data'));
    
@@ -97,9 +97,9 @@ function <<test.Test>> meta::pure::dsl::tests::testStringFunctions(): Boolean[1]
 {
    // Create a DataFrame with string functions
    let df = select([
-      upper(col('name'))->as('upper_name'),
-      lower(col('name'))->as('lower_name'),
-      length(col('name'))->as('name_length')
+      upper(~name)->as('upper_name'),
+      lower(~name)->as('lower_name'),
+      length(~name)->as('name_length')
    ])
    ->from(table('users'));
    
@@ -143,7 +143,7 @@ function <<test.Test>> meta::pure::dsl::tests::testNestedScalarFunctions(): Bool
 {
    // Create a DataFrame with nested scalar functions
    let df = select([
-      abs(cos(col('angle')))->as('abs_cos')
+      abs(cos(~angle))->as('abs_cos')
    ])
    ->from(table('trig_data'));
    
@@ -193,7 +193,7 @@ function <<test.Test>> meta::pure::dsl::tests::testDatabaseSpecificFunctions(): 
 {
    // Create a time_bucket function (which has different names across databases)
    let df = select([
-      time_bucket(literal('1 hour'), col('event_time'))->as('hour_bucket')
+      time_bucket(literal('1 hour'), ~event_time)->as('hour_bucket')
    ])
    ->from(table('events'));
    
@@ -220,10 +220,10 @@ function <<test.Test>> meta::pure::dsl::tests::testConditionalFunctions(): Boole
 {
    // Create a DataFrame with conditional functions
    let df = select([
-      coalesce(col('value'), literal(0))->as('coalesced_value'),
-      nullif(col('value'), literal(0))->as('nullif_value'),
-      greatest(col('value1'), col('value2'), col('value3'))->as('greatest_value'),
-      least(col('value1'), col('value2'), col('value3'))->as('least_value')
+      coalesce(~value, literal(0))->as('coalesced_value'),
+      nullif(~value, literal(0))->as('nullif_value'),
+      greatest(~value1, ~value2, ~value3)->as('greatest_value'),
+      least(~value1, ~value2, ~value3)->as('least_value')
    ])
    ->from(table('data'));
    
@@ -273,10 +273,10 @@ function <<test.Test>> meta::pure::dsl::tests::testConversionFunctions(): Boolea
 {
    // Create a DataFrame with conversion functions
    let df = select([
-      cast(col('value'), literal('INTEGER'))->as('int_value'),
-      toNumber(col('string_value'))->as('numeric_value'),
-      toDate(col('date_string'), literal('YYYY-MM-DD'))->as('date_value'),
-      toTimestamp(col('timestamp_string'), literal('YYYY-MM-DD HH24:MI:SS'))->as('timestamp_value')
+      cast(~value, literal('INTEGER'))->as('int_value'),
+      toNumber(~string_value)->as('numeric_value'),
+      toDate(~date_string, literal('YYYY-MM-DD'))->as('date_value'),
+      toTimestamp(~timestamp_string, literal('YYYY-MM-DD HH24:MI:SS'))->as('timestamp_value')
    ])
    ->from(table('data'));
    
@@ -326,12 +326,12 @@ function <<test.Test>> meta::pure::dsl::tests::testNewMathFunctions(): Boolean[1
 {
    // Create a DataFrame with new math functions
    let df = select([
-      round(col('value'), literal(2))->as('rounded_value'),
-      ceiling(col('value'))->as('ceiling_value'),
-      floor(col('value'))->as('floor_value'),
-      log(col('value'))->as('log_value'),
-      ln(col('value'))->as('ln_value'),
-      mod(col('value'), literal(5))->as('mod_value')
+      round(~value, literal(2))->as('rounded_value'),
+      ceiling(~value)->as('ceiling_value'),
+      floor(~value)->as('floor_value'),
+      log(~value)->as('log_value'),
+      ln(~value)->as('ln_value'),
+      mod(~value, literal(5))->as('mod_value')
    ])
    ->from(table('data'));
    
@@ -394,8 +394,8 @@ function <<test.Test>> meta::pure::dsl::tests::testNewDateFunctions(): Boolean[1
    // Create a DataFrame with new date functions
    let df = select([
       currentDate()->as('today'),
-      dateAdd(literal('day'), col('date_value'), literal(7))->as('date_plus_7_days'),
-      dateSub(literal('month'), col('date_value'), literal(1))->as('date_minus_1_month')
+      dateAdd(literal('day'), ~date_value, literal(7))->as('date_plus_7_days'),
+      dateSub(literal('month'), ~date_value, literal(1))->as('date_minus_1_month')
    ])
    ->from(table('data'));
    
@@ -439,10 +439,10 @@ function <<test.Test>> meta::pure::dsl::tests::testNewStringFunctions(): Boolean
 {
    // Create a DataFrame with new string functions
    let df = select([
-      left(col('name'), literal(3))->as('name_left_3'),
-      right(col('name'), literal(3))->as('name_right_3'),
-      split(col('full_name'), literal(' '))->as('name_parts'),
-      regexpExtract(col('text'), literal('\\d+'))->as('extracted_numbers')
+      left(~name, literal(3))->as('name_left_3'),
+      right(~name, literal(3))->as('name_right_3'),
+      split(~full_name, literal(' '))->as('name_parts'),
+      regexpExtract(~text, literal('\\d+'))->as('extracted_numbers')
    ])
    ->from(table('users'));
    
@@ -492,9 +492,9 @@ function <<test.Test>> meta::pure::dsl::tests::testNestedNewFunctions(): Boolean
 {
    // Create a DataFrame with nested new functions
    let df = select([
-      ceiling(round(col('value'), literal(2)))->as('ceiling_of_rounded'),
-      coalesce(nullif(col('value'), literal(0)), literal(1))->as('safe_value'),
-      left(upper(col('name')), literal(3))->as('upper_left_3')
+      ceiling(round(~value, literal(2)))->as('ceiling_of_rounded'),
+      coalesce(nullif(~value, literal(0)), literal(1))->as('safe_value'),
+      left(upper(~name), literal(3))->as('upper_left_3')
    ])
    ->from(table('data'));
    

--- a/src/test/resources/pure/dsl/tests/typesafe_tests.pure
+++ b/src/test/resources/pure/dsl/tests/typesafe_tests.pure
@@ -27,7 +27,7 @@ import meta::pure::dsl::bigquery::*;
 function <<test.Test>> meta::pure::dsl::tests::testTypeSafeColSpec(): Boolean[1]
 {
    // Test ColSpec creation with tilde notation
-   let col = ~'column1';
+   let col = ~column1;
    assertEquals('column1', $col.name);
    
    // Test ColSpecArray creation with tilde notation
@@ -41,19 +41,19 @@ function <<test.Test>> meta::pure::dsl::tests::testTypeSafeColSpec(): Boolean[1]
 function <<test.Test>> meta::pure::dsl::tests::testTypeSafeAggregateFunctions(): Boolean[1]
 {
    // Test type-safe aggregate functions
-   let sumCol = sum(~'value');
+   let sumCol = sum(~value);
    assertEquals('sum_value', $sumCol.name);
    
-   let avgCol = avg(~'price');
+   let avgCol = avg(~price);
    assertEquals('avg_price', $avgCol.name);
    
-   let minCol = min(~'score');
+   let minCol = min(~score);
    assertEquals('min_score', $minCol.name);
    
-   let maxCol = max(~'rating');
+   let maxCol = max(~rating);
    assertEquals('max_rating', $maxCol.name);
    
-   let countCol = count(~'id');
+   let countCol = count(~id);
    assertEquals('count_id', $countCol.name);
    
    true;
@@ -63,7 +63,7 @@ function <<test.Test>> meta::pure::dsl::tests::testTypeSafeAggregateFunctions():
 function <<test.Test>> meta::pure::dsl::tests::testTypeSafeWindowSpec(): Boolean[1]
 {
    // Test window specification with tilde notation
-   let windowSpec1 = over(~'department');
+   let windowSpec1 = over(~department);
    assertEquals(['department'], $windowSpec1.partition);
    assertEquals([], $windowSpec1.sortInfo);
    
@@ -72,13 +72,13 @@ function <<test.Test>> meta::pure::dsl::tests::testTypeSafeWindowSpec(): Boolean
    assertEquals([], $windowSpec2.sortInfo);
    
    // Test with sort info
-   let windowSpec3 = over(~'department', [asc(~'salary')]);
+   let windowSpec3 = over(~department, [asc(~salary)]);
    assertEquals(['department'], $windowSpec3.partition);
    assertEquals('salary', $windowSpec3.sortInfo->at(0).column);
    assertEquals(meta::pure::dsl::dataframe::metamodel::window::SortDirection.ASC, $windowSpec3.sortInfo->at(0).direction);
    
    // Test with multiple sort columns
-   let windowSpec4 = over(~['region', 'department'], [asc(~'date'), desc(~'id')]);
+   let windowSpec4 = over(~['region', 'department'], [asc(~date), desc(~id)]);
    assertEquals(['region', 'department'], $windowSpec4.partition);
    assertEquals('date', $windowSpec4.sortInfo->at(0).column);
    assertEquals('id', $windowSpec4.sortInfo->at(1).column);


### PR DESCRIPTION
- Updated ColumnReference class to use ColSpec instead of String for column names
- Removed col() functions completely
- Replaced all col() usage with tilde notation for column references
- Updated tests and examples to use tilde notation
- Updated functions to use existing ColSpec arguments directly instead of creating new ones

Link to Devin run: https://app.devin.ai/sessions/49efb237b77b4b1da4147e426e4cd968
Requested by: neema.raphael@gs.com